### PR TITLE
Increase the defined max word length to 16 to match wallet names

### DIFF
--- a/common/coin_support/wallet.h
+++ b/common/coin_support/wallet.h
@@ -42,7 +42,7 @@
 #define MAX_NUMBER_OF_MNEMONIC_WORDS 24
 
 /// Max length of mnemonic word
-#define MAX_MNEMONIC_WORD_LENGTH 15
+#define MAX_MNEMONIC_WORD_LENGTH 16
 
 /// Max length of passphrase entered
 #define MAX_PASSPHRASE_INPUT_LENGTH 65

--- a/common/interfaces/user_interface/ui_list.c
+++ b/common/interfaces/user_interface/ui_list.c
@@ -63,7 +63,7 @@
 static struct List_Data* data = NULL;
 static struct List_Object* obj = NULL;
 
-void list_init(const char option_list[24][15], const int number_of_options, const char* heading, bool dynamic_heading)
+void list_init(const char option_list[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH], const int number_of_options, const char* heading, bool dynamic_heading)
 {
     ASSERT(option_list != NULL);
     ASSERT(heading != NULL);

--- a/common/interfaces/user_interface/ui_list.h
+++ b/common/interfaces/user_interface/ui_list.h
@@ -23,7 +23,7 @@
  * @note
  */
 struct List_Data {
-	char option_list[24][15];
+	char option_list[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH];
 	int number_of_options;
 	int current_index;
 	bool dynamic_heading;
@@ -65,7 +65,7 @@ struct List_Object {
  *
  * @note Do not use this if number of options to be displayed in list is 1.
  */
-void list_init(const char option_list[24][15], int number_of_options, const char *heading, bool dynamic_heading);
+void list_init(const char option_list[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH], int number_of_options, const char *heading, bool dynamic_heading);
 
 /**
  * @brief Create UI for list

--- a/common/libraries/util/utils.c
+++ b/common/libraries/util/utils.c
@@ -152,7 +152,7 @@ uint32_t byte_array_to_hex_string(const uint8_t *bytes, const uint32_t byte_len,
     return (i * 2 + 1);
 }
 
-void __single_to_multi_line(const char* input, const uint16_t input_len, char output[24][15])
+void __single_to_multi_line(const char* input, const uint16_t input_len, char output[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH])
 {
     if (input == NULL || output == NULL) return;
     uint16_t i = 0U;
@@ -174,7 +174,7 @@ void __single_to_multi_line(const char* input, const uint16_t input_len, char ou
     }
 }
 
-void __multi_to_single_line(const char input[24][15], const uint8_t number_of_mnemonics, char* output)
+void __multi_to_single_line(const char input[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH], const uint8_t number_of_mnemonics, char* output)
 {
     if (input == NULL || output == NULL) return;
     uint8_t word_len;

--- a/common/libraries/util/utils.h
+++ b/common/libraries/util/utils.h
@@ -131,7 +131,7 @@ uint32_t byte_array_to_hex_string(const uint8_t *bytes, uint32_t len, char *hex_
  *
  * @note
  */
-void __single_to_multi_line(const char* input, uint16_t input_len, char output[24][15]);
+void __single_to_multi_line(const char* input, uint16_t input_len, char output[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH]);
 
 /**
  * @brief  convert multi-d mnemonics to single-d array for trezor crypto functions
@@ -149,7 +149,7 @@ void __single_to_multi_line(const char* input, uint16_t input_len, char output[2
  *
  * @note
  */
-void __multi_to_single_line(const char input[24][15], uint8_t number_of_mnemonics, char *output);
+void __multi_to_single_line(const char input[MAX_NUMBER_OF_MNEMONIC_WORDS][MAX_MNEMONIC_WORD_LENGTH], uint8_t number_of_mnemonics, char *output);
 
 /**
  * @brief Converts a hex string to a byte array.

--- a/src/level_four/card_health_check/cyt_card_hc.c
+++ b/src/level_four/card_health_check/cyt_card_hc.c
@@ -105,7 +105,7 @@ void cyt_card_hc() {
                 message_scr_init(ui_text_no_wallets_present);
             }
             else if(wallet_count <= MAX_WALLETS_ALLOWED){
-                char choices[MAX_WALLETS_ALLOWED][15]={"","","",""}, heading[50];
+                char choices[MAX_WALLETS_ALLOWED][16]={"","","",""}, heading[50];
                 for(int i=0; i < wallet_count; i++){
                     strcpy(choices[i], (char*)wallet_list[i][0]);
                 }


### PR DESCRIPTION
The ui_list component is defined with rows size of 15 in one of its parameter. Using the component to list wallet names results in trimming of last letter of the wallet name.

Fixes https://app.clickup.com/t/37308523/CHI-2010