### PR TITLE
Remove unnecessary calls to comm_process_complete 

### DIFF
--- a/src/level_four/core/controller/initial_verify_card_controller.c
+++ b/src/level_four/core/controller/initial_verify_card_controller.c
@@ -246,13 +246,11 @@ void initial_verify_card_controller()
 
     case VERIFY_CARD_FINAL_MESSAGE: {
         instruction_scr_destructor();
-        comm_process_complete();
         reset_flow_level();
         flow_level.level_one = 7;
     } break;
 
     case VERIFY_CARD_FAILED:
-        comm_process_complete();
         reset_flow_level();
         flow_level.level_one = 6;
         break;

--- a/src/level_four/core/controller/initial_verify_card_controller.c
+++ b/src/level_four/core/controller/initial_verify_card_controller.c
@@ -251,6 +251,7 @@ void initial_verify_card_controller()
     } break;
 
     case VERIFY_CARD_FAILED:
+        comm_process_complete();
         reset_flow_level();
         flow_level.level_one = 6;
         break;

--- a/src/level_four/core/controller/verify_card_controller.c
+++ b/src/level_four/core/controller/verify_card_controller.c
@@ -187,7 +187,13 @@ void verify_card_controller()
         En_command_type_t msg_type;
         uint8_t *data_array = NULL;
         uint16_t msg_size = 1;
-        get_usb_msg(&msg_type, &data_array, &msg_size);
+
+        if (!get_usb_msg(&msg_type, &data_array, &msg_size)) return;
+        if (msg_type != STATUS_PACKET) {
+            comm_reject_invalid_cmd();
+            clear_message_received_data();
+            return;
+        }
 
         if (msg_type == STATUS_PACKET && data_array[0] == STATUS_CMD_SUCCESS)
             flow_level.level_three = VERIFY_CARD_SUCCESS;


### PR DESCRIPTION
Fixes https://app.clickup.com/t/37308523/CHI-2044
The comm_process_complete will clear the cmdState to NONE which will essentially result into the device's last response being discarded. As a result the desktop never receives the device's response.