### PR TITLE
Correct time calculation for overflow condition

### DIFF
--- a/common/libraries/util/pow_utilities.c
+++ b/common/libraries/util/pow_utilities.c
@@ -88,18 +88,16 @@ void pow_get_approx_time_in_secs(const uint8_t target[SHA256_SIZE], uint32_t* ti
         }
     }
 
-    if ((256U - number_bits_set) > 31U) {
+    if ((256U - number_bits_set) > 63U) {
         // This is too long of a time to calculate, just return
-        *time_in_secs_out = 99U;
+        *time_in_secs_out = UINT32_MAX;
         return;
     }
 
-    uint32_t time_in_secs = 1U;
-    time_in_secs = (uint32_t)(time_in_secs << (256U - number_bits_set)) / pow_hash_rate;
+    uint64_t time_in_secs = 1U;
+    time_in_secs = (time_in_secs << (256U - number_bits_set)) / pow_hash_rate;
 
-    *time_in_secs_out = time_in_secs;
-
-    return;
+    *time_in_secs_out = CY_MIN(time_in_secs, UINT32_MAX);
 }
 
 void convert_secs_to_time(const uint32_t time_in_secs, const char wallet_name[NAME_SIZE], char out_string[MAX_NUM_OF_CHARS_IN_A_SLIDE])

--- a/common/libraries/util/pow_utilities.c
+++ b/common/libraries/util/pow_utilities.c
@@ -95,6 +95,7 @@ void pow_get_approx_time_in_secs(const uint8_t target[SHA256_SIZE], uint32_t* ti
     }
 
     uint64_t time_in_secs = 1U;
+    ASSERT(pow_hash_rate != 0);
     time_in_secs = (time_in_secs << (256U - number_bits_set)) / pow_hash_rate;
 
     *time_in_secs_out = CY_MIN(time_in_secs, UINT32_MAX);


### PR DESCRIPTION
Fixes https://app.clickup.com/t/37308523/CHI-2045
The time calculation has been upper bounded to value of 99 seconds if the time overflows a 32-bit storage. Changing the upper bound to UINT32_MAX and using 64-bit storage for calculation.