### PR TITLE
feat (ci): Publish draft release post build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,27 @@ jobs:
       firmware: ${{ matrix.firmware }}
       target: ${{ matrix.target }}
     secrets: inherit
+  create-release:
+    needs: build-firmwares
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type }} == 'tag'
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@master
+      with:
+        path: ./
+    - name: Publish a release
+      env:
+        TAG_NAME: ${{ github.ref_name }}
+        auth_token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        chkmain=$(sha256sum main-release-outputs/release/Cypherock-Main.bin | cut -f -1 -d ' ')
+        chkinit=$(sha256sum initial-release-outputs/release/Cypherock-Initial.bin | cut -f -1 -d ' ')
+        curl   -X POST   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${auth_token}"  -H "X-GitHub-Api-Version: 2022-11-28"   https://api.github.com/repos/ujjwal-cyph/x1_wallet_firmware/releases   -d '{"tag_name":"'${TAG_NAME}'","target_commitish":"main","name":"'${TAG_NAME}'","body":"## SHA256 of binaries:\r\n**Cypherock-Initial.bin** : '${chkinit}' \r\n**Cypherock-Main.bin** : '${chkmain}'","draft":true,"prerelease":false,"generate_release_notes":true}' > output.txt
+        echo "upload_url=$(cat output.txt | grep "\"upload_url\":" | cut -f 4-4 -d '"' | cut -f 1-1 -d '{')" >> $GITHUB_ENV
+    - name: Upload assets
+      env:
+        auth_token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        curl   -X POST   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${auth_token}"  -H "X-GitHub-Api-Version: 2022-11-28"   ${upload_url}?name=Cypherock-Main.bin -F "data=@main-release-outputs/release/Cypherock-Main.bin"
+        curl   -X POST   -H "Accept: application/vnd.github+json"   -H "Authorization: Bearer ${auth_token}"  -H "X-GitHub-Api-Version: 2022-11-28"   ${upload_url}?name=Cypherock-Initial.bin -F "data=@initial-release-outputs/release/Cypherock-Initial.bin"


### PR DESCRIPTION
Every build generated on a tag will now publish a draft release under GitHub releases section.

The draft release will contain
1. The unsigned firmware binaries
2. The sha256 checksum of the firmware binaries
3. Link to the changelog