### PR TITLE
Use exact buffer size for ethereum addresses

### DIFF
--- a/src/level_four/core/tasks/receive_transaction_tasks_eth.c
+++ b/src/level_four/core/tasks/receive_transaction_tasks_eth.c
@@ -146,7 +146,7 @@ void receive_transaction_tasks_eth()
     case RECV_TXN_DISPLAY_ADDR_ETH: {
         instruction_scr_destructor();
         char display[70];
-        char address_s[2 + sizeof(receive_transaction_data.address) + 1] = {'0', 'x', '\0'};
+        char address_s[sizeof(receive_transaction_data.address)] = {'0', 'x', '\0'};
         uint64_t chain_id = receive_transaction_data.network_chain_id;
         if (chain_id != HARMONY_MAINNET_CHAIN && chain_id != HARMONY_TESTNET_CHAIN)
           byte_array_to_hex_string(receive_transaction_data.eth_pubkeyhash, sizeof(receive_transaction_data.eth_pubkeyhash),


### PR DESCRIPTION
Ethereum default address of the form `0xe688b84b23f322a994a53dbf8e15fa82cdb71127` is of 43 byte including the `null` character.

Also, harmony's bech32 addresses also result into 43 bytes including `null` character.

So size 43 fits both the types of addresses.