### PR TITLE
refactor: Rename change index variable from chain to change

### DIFF
--- a/common/coin_support/coin_utils.c
+++ b/common/coin_support/coin_utils.c
@@ -101,7 +101,7 @@ int64_t byte_array_to_txn_metadata(const uint8_t *metadata_byte_array, const uin
     uint8_t metadataInputIndex = 0;
     for (; metadataInputIndex < *txn_metadata_ptr->input_count; metadataInputIndex++) {
         address_type *input = &txn_metadata_ptr->input[metadataInputIndex];
-        s_memcpy(input->chain_index, metadata_byte_array, size, sizeof(input->chain_index), &offset);
+        s_memcpy(input->change_index, metadata_byte_array, size, sizeof(input->change_index), &offset);
         s_memcpy(input->address_index, metadata_byte_array, size, sizeof(input->address_index), &offset);
     }
 
@@ -115,7 +115,7 @@ int64_t byte_array_to_txn_metadata(const uint8_t *metadata_byte_array, const uin
     uint8_t metadataOutputIndex = 0;
     for (; metadataOutputIndex < 1; metadataOutputIndex++) {
         address_type *output = &txn_metadata_ptr->output[metadataOutputIndex];
-        s_memcpy(output->chain_index, metadata_byte_array, size, sizeof(output->chain_index), &offset);
+        s_memcpy(output->change_index, metadata_byte_array, size, sizeof(output->change_index), &offset);
         s_memcpy(output->address_index, metadata_byte_array, size, sizeof(output->address_index), &offset);
     } 
 
@@ -128,7 +128,7 @@ int64_t byte_array_to_txn_metadata(const uint8_t *metadata_byte_array, const uin
     uint8_t metadataChangeIndex = 0;
     for (; metadataChangeIndex < *txn_metadata_ptr->change_count; metadataChangeIndex++) {
         address_type *change = &txn_metadata_ptr->change[metadataChangeIndex];
-        s_memcpy(change->chain_index, metadata_byte_array, size, sizeof(change->chain_index), &offset);
+        s_memcpy(change->change_index, metadata_byte_array, size, sizeof(change->change_index), &offset);
         s_memcpy(change->address_index, metadata_byte_array, size, sizeof(change->address_index), &offset);
     }
 
@@ -166,7 +166,7 @@ int64_t byte_array_to_recv_txn_data(Receive_Transaction_Data *txn_data_ptr,const
     s_memcpy(txn_data_ptr->purpose, data_byte_array, size, sizeof(txn_data_ptr->purpose), &offset);
     s_memcpy(txn_data_ptr->coin_index, data_byte_array, size, sizeof(txn_data_ptr->coin_index), &offset);
     s_memcpy(txn_data_ptr->account_index, data_byte_array, size, sizeof(txn_data_ptr->account_index), &offset);
-    s_memcpy(txn_data_ptr->chain_index, data_byte_array, size, sizeof(txn_data_ptr->chain_index), &offset);
+    s_memcpy(txn_data_ptr->change_index, data_byte_array, size, sizeof(txn_data_ptr->change_index), &offset);
     s_memcpy(txn_data_ptr->address_index, data_byte_array, size, sizeof(txn_data_ptr->address_index), &offset);
 
     size_t token_name_len = strnlen((const char*)(data_byte_array+offset),size - offset ) + 1;
@@ -244,10 +244,10 @@ void get_address_node(const txn_metadata *txn_metadata_ptr, const int16_t index,
     hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->coin_index));
     hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->account_index));
     if (index == -1) {
-        hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->change[0].chain_index));
+        hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->change[0].change_index));
         hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->change[0].address_index));
     } else if (index >= 0) {
-        hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->input[index].chain_index));
+        hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->input[index].change_index));
         hdnode_private_ckd(hdnode, BYTE_ARRAY_TO_UINT32(txn_metadata_ptr->input[index].address_index));
     }
     hdnode_fill_public_key(hdnode);
@@ -463,18 +463,18 @@ bool validate_txn_metadata(const txn_metadata *mdata_ptr) {
         return false;
     if (BYTE_ARRAY_TO_UINT32(mdata_ptr->purpose_index) == NON_SEGWIT &&
         (BYTE_ARRAY_TO_UINT32(mdata_ptr->coin_index) == NEAR || BYTE_ARRAY_TO_UINT32(mdata_ptr->coin_index) == SOLANA)){
-        if (mdata_ptr->input_count[0] > 0 && (mdata_ptr->input->chain_index[0] < 0x80 ||
+        if (mdata_ptr->input_count[0] > 0 && (mdata_ptr->input->change_index[0] < 0x80 ||
                 mdata_ptr->input->address_index[0] < 0x80))
             return false;
         return true;
     }
-    if (mdata_ptr->input_count[0] > 0 && (mdata_ptr->input->chain_index[0] >= 0x80 ||
+    if (mdata_ptr->input_count[0] > 0 && (mdata_ptr->input->change_index[0] >= 0x80 ||
             mdata_ptr->input->address_index[0] >= 0x80))
         return false;
-    if (mdata_ptr->output_count[0] > 0 && (mdata_ptr->output->chain_index[0] >= 0x80 ||
+    if (mdata_ptr->output_count[0] > 0 && (mdata_ptr->output->change_index[0] >= 0x80 ||
             mdata_ptr->output->address_index[0] >= 0x80))
         return false;
-    if (mdata_ptr->change_count[0] > 0 && (mdata_ptr->change->chain_index[0] >= 0x80 ||
+    if (mdata_ptr->change_count[0] > 0 && (mdata_ptr->change->change_index[0] >= 0x80 ||
             mdata_ptr->change->address_index[0] >= 0x80))
         return false;
     if (mdata_ptr->eth_val_decimal[0] > 18) return false;

--- a/common/coin_support/coin_utils.h
+++ b/common/coin_support/coin_utils.h
@@ -92,7 +92,7 @@ typedef enum Coin_Type {
  */
 typedef struct
 {
-    uint8_t chain_index[4];
+    uint8_t change_index[4];
     uint8_t address_index[4];
 } address_type;
 #pragma pack(pop)
@@ -167,7 +167,7 @@ typedef struct Receive_Transaction_Data {
   uint8_t purpose[4];
   uint8_t coin_index[4];
   uint8_t account_index[4];
-  uint8_t chain_index[4];
+  uint8_t change_index[4];
   uint8_t address_index[4];
   char *token_name;
   union {

--- a/common/coin_support/near.c
+++ b/common/coin_support/near.c
@@ -119,7 +119,7 @@ void near_sig_unsigned_byte_array(const uint8_t *unsigned_txn_byte_array, uint64
       BYTE_ARRAY_TO_UINT32(transaction_metadata->purpose_index),
       BYTE_ARRAY_TO_UINT32(transaction_metadata->coin_index),
       BYTE_ARRAY_TO_UINT32(transaction_metadata->account_index),
-      BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].chain_index),
+      BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].change_index),
       BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].address_index)
     };
     uint8_t seed[64]={0};

--- a/common/coin_support/solana.c
+++ b/common/coin_support/solana.c
@@ -198,7 +198,7 @@ void solana_sig_unsigned_byte_array(const uint8_t *unsigned_txn_byte_array,
   uint32_t path[]  = {BYTE_ARRAY_TO_UINT32(transaction_metadata->purpose_index),
                       BYTE_ARRAY_TO_UINT32(transaction_metadata->coin_index),
                       BYTE_ARRAY_TO_UINT32(transaction_metadata->account_index),
-                      BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].chain_index),
+                      BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].change_index),
                       BYTE_ARRAY_TO_UINT32(transaction_metadata->input[0].address_index)};
   size_t depth = sol_get_derivation_depth(transaction_metadata->address_tag);
   uint8_t seed[64] = {0};

--- a/src/controller_main.c
+++ b/src/controller_main.c
@@ -550,7 +550,7 @@ void desktop_listener_task(lv_task_t* data)
                         BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.purpose_index),
                         BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.coin_index),
                         BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.account_index),
-                        BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.input[0].chain_index),
+                        BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.input[0].change_index),
                         BYTE_ARRAY_TO_UINT32(var_send_transaction_data.transaction_metadata.input[0].address_index)};
 
                     flow_level.show_desktop_start_screen = true;
@@ -618,7 +618,7 @@ void desktop_listener_task(lv_task_t* data)
                         BYTE_ARRAY_TO_UINT32(receive_transaction_data.purpose),
                         BYTE_ARRAY_TO_UINT32(receive_transaction_data.coin_index),
                         BYTE_ARRAY_TO_UINT32(receive_transaction_data.account_index),
-                        BYTE_ARRAY_TO_UINT32(receive_transaction_data.chain_index),
+                        BYTE_ARRAY_TO_UINT32(receive_transaction_data.change_index),
                         BYTE_ARRAY_TO_UINT32(receive_transaction_data.address_index)};
                     uint8_t depth =
                         path[1] == SOLANA ? sol_get_derivation_depth(receive_transaction_data.address_tag) : 5;

--- a/src/level_four/core/controller/receive_transaction_controller.c
+++ b/src/level_four/core/controller/receive_transaction_controller.c
@@ -170,7 +170,7 @@ void receive_transaction_controller()
 
         hdnode_fill_public_key(&node);
 
-        hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.chain_index));
+        hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.change_index));
         hdnode_fill_public_key(&node);
         hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.address_index));
         hdnode_fill_public_key(&node);

--- a/src/level_four/core/controller/receive_transaction_controller_eth.c
+++ b/src/level_four/core/controller/receive_transaction_controller_eth.c
@@ -164,7 +164,7 @@ void receive_transaction_controller_eth()
 
         hdnode_fill_public_key(&node);
 
-        hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.chain_index));
+        hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.change_index));
         hdnode_fill_public_key(&node);
         hdnode_public_ckd(&node, BYTE_ARRAY_TO_UINT32(receive_transaction_data.address_index));
         hdnode_fill_public_key(&node);

--- a/src/level_four/core/controller/receive_transaction_controller_near.c
+++ b/src/level_four/core/controller/receive_transaction_controller_near.c
@@ -186,7 +186,7 @@ void receive_transaction_controller_near()
             BYTE_ARRAY_TO_UINT32(receive_transaction_data.purpose),
             BYTE_ARRAY_TO_UINT32(receive_transaction_data.coin_index),
             BYTE_ARRAY_TO_UINT32(receive_transaction_data.account_index),
-            BYTE_ARRAY_TO_UINT32(receive_transaction_data.chain_index),
+            BYTE_ARRAY_TO_UINT32(receive_transaction_data.change_index),
             BYTE_ARRAY_TO_UINT32(receive_transaction_data.address_index),
         };
         derive_hdnode_from_path(path, 5, ED25519_NAME, seed, &node);

--- a/src/level_four/core/controller/receive_transaction_controller_solana.c
+++ b/src/level_four/core/controller/receive_transaction_controller_solana.c
@@ -152,7 +152,7 @@ void receive_transaction_controller_solana() {
           BYTE_ARRAY_TO_UINT32(receive_transaction_data.purpose),
           BYTE_ARRAY_TO_UINT32(receive_transaction_data.coin_index),
           BYTE_ARRAY_TO_UINT32(receive_transaction_data.account_index),
-          BYTE_ARRAY_TO_UINT32(receive_transaction_data.chain_index),
+          BYTE_ARRAY_TO_UINT32(receive_transaction_data.change_index),
           BYTE_ARRAY_TO_UINT32(receive_transaction_data.address_index),
       };
       size_t depth = sol_get_derivation_depth(receive_transaction_data.address_tag);


### PR DESCRIPTION
Currently the level four of HD Key path variable is named `chain_index` which is wrong as the level four is known as `Change index`. So the relevant name for all such variable is `change_index`.