### PR TITLE
Improvement/wallet id check after shamir reconstruction/chi 4556

### DIFF
--- a/common/coin_support/wallet.c
+++ b/common/coin_support/wallet.c
@@ -61,6 +61,7 @@
 #include <string.h>
 #include "rfc7539.h"
 #include "options.h"
+#include "wallet_utilities.h"
 
 /// Global Wallet instance.
 Wallet CONFIDENTIAL wallet = {
@@ -165,3 +166,17 @@ bool verify_checksum(const Wallet *wallet) {
     calculate_checksum(wallet, checksum);
     return (memcmp(wallet->checksum, checksum, sizeof(wallet->checksum)) == 0);
 }
+
+bool check_wallet_id(const Wallet *p_selected_wallet, const char *p_mnemonics) {
+    if ((NULL == p_selected_wallet) || (NULL == p_mnemonics)) {
+        return false;
+    }
+
+    uint8_t recovered_wallet_id[WALLET_ID_SIZE];
+    memzero(recovered_wallet_id, WALLET_ID_SIZE);
+        
+    calculate_wallet_id(&(recovered_wallet_id[0]), p_mnemonics);
+    return (memcmp(&(recovered_wallet_id[0]), &(p_selected_wallet->wallet_id[0]), WALLET_ID_SIZE) == 0); 
+}
+
+

--- a/common/coin_support/wallet.h
+++ b/common/coin_support/wallet.h
@@ -240,4 +240,19 @@ void calculate_checksum(const Wallet *wallet, uint8_t *checksum);
  */
 bool verify_checksum(const Wallet *wallet);
 
+/**
+ * @brief This function verifies if mnemonics correspond to a particular wallet
+ * This function computes the wallet_id from p_menmonics and compares the result
+ * against wallet_id member of struct Wallet
+ * It is assumed that wallet_id is popoulated in struct pointed by p_selected_wallet
+ * @param p_selected_wallet : Pointer to a Wallet instance
+ * @param p_mnemonics: Pointer to mnemonics 
+ *
+ * @return Wallet ID comparison status 
+ * @retval true If the mnemonics result in the same wallet ID as populated in p_selected_wallet 
+ * @retval false Otherwise
+ */
+bool check_wallet_id(const Wallet *p_selected_wallet, const char *p_mnemonics); 
+
 #endif
+

--- a/src/controller_main.c
+++ b/src/controller_main.c
@@ -438,6 +438,7 @@ static bool wallet_selector(uint8_t *data_array)
     for (; walletIndex < MAX_WALLETS_ALLOWED; walletIndex++) {
         if (memcmp(wallet_id, get_wallet_id(walletIndex), WALLET_ID_SIZE) == 0) {
             if (get_wallet_state(walletIndex) == VALID_WALLET) {
+                memcpy(wallet.wallet_id, wallet_id, WALLET_ID_SIZE);
                 memcpy(wallet.wallet_name, get_wallet_name(walletIndex), NAME_SIZE);
                 wallet.wallet_info = get_wallet_info(walletIndex);
                 if (is_wallet_partial(walletIndex)) {

--- a/src/level_four/core/controller/add_coin_controller.c
+++ b/src/level_four/core/controller/add_coin_controller.c
@@ -146,6 +146,10 @@ void add_coin_controller()
         const char* mnemo = mnemonic_from_data(secret,wallet.number_of_mnemonics * 4 / 3);
 
         ASSERT(mnemo != NULL);
+
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
         uint8_t seed[64]={0};
         const char *curve = NULL;
         const uint32_t coin_index = add_coin_data.derivation_path[1];

--- a/src/level_four/core/controller/receive_transaction_controller.c
+++ b/src/level_four/core/controller/receive_transaction_controller.c
@@ -148,6 +148,10 @@ void receive_transaction_controller()
         memzero(wallet_shamir_data.share_encryption_data, sizeof(wallet_shamir_data.share_encryption_data));
         mnemonic_clear();
         const char* mnemo = mnemonic_from_data(secret,wallet.number_of_mnemonics * 4 / 3);
+        
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+        
         HDNode node;
         uint8_t seed[64];
 

--- a/src/level_four/core/controller/receive_transaction_controller_eth.c
+++ b/src/level_four/core/controller/receive_transaction_controller_eth.c
@@ -145,6 +145,10 @@ void receive_transaction_controller_eth()
         memzero(wallet_shamir_data.mnemonic_shares, sizeof(wallet_shamir_data.mnemonic_shares));
         mnemonic_clear();
         const char* mnemo = mnemonic_from_data(secret,wallet.number_of_mnemonics * 4 / 3);
+
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
         HDNode node;
         uint8_t seed[64];
 

--- a/src/level_four/core/controller/receive_transaction_controller_near.c
+++ b/src/level_four/core/controller/receive_transaction_controller_near.c
@@ -173,6 +173,10 @@ void receive_transaction_controller_near()
         memzero(wallet_shamir_data.share_encryption_data, sizeof(wallet_shamir_data.share_encryption_data));
         mnemonic_clear();
         const char* mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
+
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
         HDNode node;
         uint8_t seed[64]={0};
 

--- a/src/level_four/core/controller/receive_transaction_controller_solana.c
+++ b/src/level_four/core/controller/receive_transaction_controller_solana.c
@@ -139,6 +139,10 @@ void receive_transaction_controller_solana() {
       memzero(wallet_shamir_data.mnemonic_shares, sizeof(wallet_shamir_data.mnemonic_shares));
       mnemonic_clear();
       const char *mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
+
+      /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+      ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
       HDNode node;
       uint8_t seed[64] = {0};
 

--- a/src/level_four/core/controller/send_transaction_controller.c
+++ b/src/level_four/core/controller/send_transaction_controller.c
@@ -220,6 +220,10 @@ void send_transaction_controller()
             secret);
         mnemonic_clear();
         const char* mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
+
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
         if (input_index == 0 && !validate_change_address(&var_send_transaction_data.unsigned_transaction,
             &var_send_transaction_data.transaction_metadata, mnemo, wallet_credential_data.passphrase)) {
             instruction_scr_destructor();

--- a/src/level_four/core/controller/send_transaction_controller_eth.c
+++ b/src/level_four/core/controller/send_transaction_controller_eth.c
@@ -232,6 +232,9 @@ void send_transaction_controller_eth()
         const char* mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
         ASSERT(mnemo != NULL);
 
+        /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+        ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
         uint8_t sig[65];
         sig_unsigned_byte_array(eth_unsigned_txn_byte_array, eth_unsigned_txn_len,
                 (const txn_metadata*) &var_send_transaction_data.transaction_metadata, mnemo, wallet_credential_data.passphrase, sig);

--- a/src/level_four/core/controller/send_transaction_controller_near.c
+++ b/src/level_four/core/controller/send_transaction_controller_near.c
@@ -187,6 +187,9 @@ void send_transaction_controller_near() {
             const char* mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
             ASSERT(mnemo != NULL);
 
+            /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+            ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
             uint8_t sig[64];
             near_sig_unsigned_byte_array(near_unsigned_txn_byte_array, near_unsigned_txn_len,
                                     (const txn_metadata*) &var_send_transaction_data.transaction_metadata, mnemo, wallet_credential_data.passphrase, sig);

--- a/src/level_four/core/controller/send_transaction_controller_solana.c
+++ b/src/level_four/core/controller/send_transaction_controller_solana.c
@@ -223,6 +223,9 @@ void send_transaction_controller_solana() {
       const char *mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
       ASSERT(mnemo != NULL);
 
+      /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+      ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
       uint8_t sig[64];
       solana_sig_unsigned_byte_array(solana_unsigned_txn_byte_array, solana_unsigned_txn_len,
                                      (const txn_metadata *)&var_send_transaction_data.transaction_metadata, mnemo,

--- a/src/level_four/core/controller/sign_message_controller_eth.c
+++ b/src/level_four/core/controller/sign_message_controller_eth.c
@@ -181,6 +181,9 @@ void sign_message_controller_eth() {
             const char *mnemo = mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
             ASSERT(mnemo != NULL);
 
+            /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+            ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
             uint8_t sig[65] = {0};
 
             eth_sign_msg_data(&msg_data,

--- a/src/level_one/controller/controller_level_one.c
+++ b/src/level_one/controller/controller_level_one.c
@@ -148,6 +148,7 @@ void level_one_controller()
             }
             cy_exit_flow();
         }
+        memcpy(wallet.wallet_id, get_wallet_id(index), WALLET_ID_SIZE);
         memcpy(
             wallet.wallet_name,
             get_wallet_name(index), NAME_SIZE);

--- a/src/level_three/old_wallet/tasks/tasks_view_seeds.c
+++ b/src/level_three/old_wallet/tasks/tasks_view_seeds.c
@@ -135,6 +135,10 @@ void view_seed_task()
             const char *mnemo = mnemonic_from_data(secret, BLOCK_SIZE);
 
             ASSERT(mnemo != NULL);
+
+            /* Assert if the recovered mnemonics match the corresponding wallet_id of the selected wallet */ 
+            ASSERT (true == check_wallet_id((const Wallet *)&wallet, mnemo));
+ 
             __single_to_multi_line(mnemo, strnlen(mnemo, MAX_NUMBER_OF_MNEMONIC_WORDS * MAX_MNEMONIC_WORD_LENGTH), words);
             mnemonic_clear();
 


### PR DESCRIPTION
This change enables wallet_id check after mnemonics is restored from the shamir shares