### PR TITLE
fix (simulator): Correct linker options and main definition

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,9 @@
 #endif //USE_SIMULATOR
 
 #if USE_SIMULATOR == 1
+#ifdef _WIN32
 #define main SDL_main
+#endif
 #include "sim_usb.h"
 extern lv_indev_t *indev_keypad;
 #endif

--- a/utilities/cmake/simulator.cmake
+++ b/utilities/cmake/simulator.cmake
@@ -99,4 +99,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
         )
 
 target_link_libraries(${EXECUTABLE} PRIVATE ${SDL2_LIBRARIES} -lm)
+target_link_options(${EXECUTABLE} PRIVATE ${inherited})
 add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/${EXECUTABLE})

--- a/utilities/cmake/simulator.cmake
+++ b/utilities/cmake/simulator.cmake
@@ -98,6 +98,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
         simulator/USB
         )
 
-target_link_libraries(${EXECUTABLE} PRIVATE ${SDL2_LIBRARIES})
-target_link_options(${EXECUTABLE} PRIVATE ${inherited} -lSDL2 -lm)
+target_link_libraries(${EXECUTABLE} PRIVATE ${SDL2_LIBRARIES} -lm)
 add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/${EXECUTABLE})


### PR DESCRIPTION
1. Simulator binary linker changes
The 'release' variant of simulator binary is having problem with current linker options of math library. The cmake method `target_link_options` does not allow linking of static libraries. Now using cmake method `target_link_libraries` to link the math library.

2. Function definition change
The simulator binary for Windows platform uses `SDL_main` in place of `main` function as entry point. But the simulator binary on unix platform accepts the `main` function as entry point. So wrapping the macro only for Windows platform.