### PR TITLE
feat (ci): Add build test on PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,47 @@
+name: Build Test CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build-firmwares:
+    strategy:
+      fail-fast: false
+      matrix:
+        firmware: [main, initial]
+        target: [release, dev]
+        platform: [device, simulator]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - shell: bash
+      env:
+        GET_KEY: ${{ secrets.GET_KEY }}
+        PLATFORM: ${{ matrix.platform }}
+      run: |
+        if [[ "${PLATFORM}" == "device" ]]; then
+          $GET_KEY && cp privatekeypairs/*.h utilities/script/
+        fi
+
+    - name: Install dependencies
+      env:
+        PLATFORM: ${{ matrix.platform }}
+      run: |
+        if [[ "${PLATFORM}" == "simulator" ]]; then
+          sudo apt install ninja-build cmake bash git libsdl2-dev -y
+        else
+          sudo apt install gcc-arm-none-eabi ninja-build cmake bash git python3 pip -y
+          pip install -r utilities/script/requirements.txt
+        fi
+
+    # Todo: run clang-checks
+    # Todo: run clang-tidy
+
+    - name: Build binaries
+      run: ./utilities/build.sh ${{ matrix.firmware }} ${{ matrix.target }} ${{ matrix.platform }}


### PR DESCRIPTION
With this workflow, the idea is that every PR goes through a build-test step to ensure all the binaries are building successfully.

Builds that will be attempted:
1. Release and dev build of target binaries of Main and Initial firmwares
2. Release and dev build of simulator binaries of Main and Initial firmwares