### PR TITLE
feat (git-hook): Add pre-commit hook

### DIFF
--- a/utilities/hooks/pre-commit
+++ b/utilities/hooks/pre-commit
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Run clang-format
+CLANG_FORMAT_EXECUTABLE="clang-format"
+
+if ! command -v $CLANG_FORMAT_EXECUTABLE &> /dev/null
+then
+  echo $CLANG_FORMAT_EXECUTABLE does not exist, make sure to install it
+  exit 1
+fi
+
+for FILE in $(git diff --cached --name-only)
+do
+  [ -e "$FILE" ] || continue
+  case "$FILE" in
+
+  common/lvgl/*|common/libraries/atecc/*|common/libraries/crypto/*|common/libraries/nanopb/*) continue ;;
+
+  *.c|*.h|*.cpp|*.hpp)
+    echo Autoformatting $FILE with $CLANG_FORMAT_EXECUTABLE
+    $CLANG_FORMAT_EXECUTABLE -style=file -i -- $FILE
+    git add -- $FILE
+  esac
+done
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --

--- a/utilities/install-hooks.sh
+++ b/utilities/install-hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+chmod +x utilities/hooks/*
+cp -r utilities/hooks .git/


### PR DESCRIPTION
The hook enforces following rules:
- Perform clang-format changes
- Prevent any non-ASCII filenames
- Whitespace error check