### PR TITLE
Correct git commit list for checking commit message

### DIFF
--- a/utilities/ci/test-commit-msg.sh
+++ b/utilities/ci/test-commit-msg.sh
@@ -2,13 +2,16 @@
 EXIT_STATUS=1
 
 if [[ $# -lt 2 ]]; then
-    echo -e "USAGE: $0 <BASE_COMMIT_ID> <HEAD_COMMIT_ID>"
+    echo -e "USAGE: $0 <BASE_BRANCH_COMMIT_ID> <WORK_BRANCH_COMMIT_ID>"
     exit ${EXIT_STATUS}
 fi
 
-BASE_SHA=$1
-HEAD_SHA=$2
-COMMIT_LIST=$(git log --format=%H $BASE_SHA...$HEAD_SHA)
+BASE_BRANCH_SHA=$1
+WORK_BRANCH_SHA=$2
+
+# generate list of commits in the that will be merged in the base branch
+# Ref: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot
+COMMIT_LIST=$(git log --format=%H $BASE_BRANCH_SHA..$WORK_BRANCH_SHA)
 EXIT_STATUS=0
 
 for COMMIT in $COMMIT_LIST; do


### PR DESCRIPTION
The commit msg check is failing wrongly. Ref: https://github.com/Cypherock/x1_wallet_firmware/actions/runs/4618412812/jobs/8165835615.

The current list of commit is generated out of both the work and base branches. We only need commits from the work branch that will be added to base branch. Ref: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot