### PR TITLE
refactor(ui): Call ui destructor from `lv_event_delete` case

### DIFF
--- a/common/interfaces/user_interface/ui_address.c
+++ b/common/interfaces/user_interface/ui_address.c
@@ -90,6 +90,13 @@ void address_scr_init(const char text[],
   ASSERT(text != NULL);
   ASSERT(address != NULL);
 
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = malloc(sizeof(struct Address_Data));
   obj = malloc(sizeof(struct Address_Object));
 
@@ -122,7 +129,6 @@ void address_scr_init(const char text[],
  * @note
  */
 static void address_scr_destructor() {
-  lv_obj_clean(lv_scr_act());
   if (data != NULL) {
     memzero(data, sizeof(struct Address_Data));
     free(data);
@@ -151,11 +157,9 @@ static void address_scr_destructor() {
  */
 static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
                                      const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(cancel_btn != NULL);
-  if (lv_obj_get_hidden(cancel_btn))
+  if ((LV_EVENT_DELETE != event) && (lv_obj_get_hidden(cancel_btn))) {
     return;
+  }
 
   switch (event) {
     case LV_EVENT_KEY:
@@ -167,14 +171,20 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      address_scr_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(cancel_btn, LV_BTN_STATE_REL);
       break;
-
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      address_scr_destructor();
+      break;
+    }
     default:
       break;
   }
@@ -196,11 +206,9 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
  * @note
  */
 static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(next_btn != NULL);
-  if (lv_obj_get_hidden(next_btn))
+  if ((LV_EVENT_DELETE != event) && (lv_obj_get_hidden(next_btn))) {
     return;
+  }
 
   switch (event) {
     case LV_EVENT_KEY:
@@ -213,13 +221,20 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      address_scr_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(next_btn, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      address_scr_destructor();
+      break;
+    }
 
     default:
       break;

--- a/common/interfaces/user_interface/ui_confirmation.c
+++ b/common/interfaces/user_interface/ui_confirmation.c
@@ -193,7 +193,7 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
       break;
     case LV_EVENT_CLICKED:
       ui_set_cancel_event();
-      confirm_scr_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(cancel_btn, LV_BTN_STATE_REL);

--- a/common/interfaces/user_interface/ui_confirmation.c
+++ b/common/interfaces/user_interface/ui_confirmation.c
@@ -70,6 +70,13 @@ static struct Confirm_Object *obj = NULL;
 void confirm_scr_init(const char *text) {
   ASSERT(text != NULL);
 
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = malloc(sizeof(struct Confirm_Data));
   obj = malloc(sizeof(struct Confirm_Object));
 
@@ -99,7 +106,6 @@ void confirm_scr_init(const char *text) {
  * @note
  */
 static void confirm_scr_destructor() {
-  lv_obj_clean(lv_scr_act());
   if (data != NULL) {
     memzero(data, sizeof(struct Confirm_Data));
     free(data);
@@ -127,8 +133,6 @@ static void confirm_scr_destructor() {
  * @note
  */
 static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
-  ASSERT(next_btn != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -140,14 +144,20 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      confirm_scr_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(next_btn, LV_BTN_STATE_REL);
       break;
-
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      confirm_scr_destructor();
+      break;
+    }
     default:
       break;
   }
@@ -170,8 +180,6 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
  */
 static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
                                      const lv_event_t event) {
-  ASSERT(cancel_btn != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -190,7 +198,12 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(cancel_btn, LV_BTN_STATE_REL);
       break;
-
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      confirm_scr_destructor();
+      break;
+    }
     default:
       break;
   }

--- a/common/interfaces/user_interface/ui_delay.c
+++ b/common/interfaces/user_interface/ui_delay.c
@@ -58,6 +58,8 @@
  */
 #include "ui_delay.h"
 
+#include "ui_events_priv.h"
+
 static lv_obj_t *instruction;
 
 void delay_scr_init(const char message[], const uint32_t delay_in_ms) {

--- a/common/interfaces/user_interface/ui_delay.c
+++ b/common/interfaces/user_interface/ui_delay.c
@@ -64,6 +64,13 @@ void delay_scr_init(const char message[], const uint32_t delay_in_ms) {
   ASSERT(message != NULL);
   ASSERT(delay_in_ms != 0);
 
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   instruction = lv_label_create(lv_scr_act(), NULL);
 
   ui_paragraph(
@@ -79,6 +86,8 @@ void delay_scr_init(const char message[], const uint32_t delay_in_ms) {
 
   BSP_DelayMs(delay_in_ms);
   lv_obj_clean(lv_scr_act());
-  if (ui_mark_event_over)
-    (*ui_mark_event_over)();
+
+  /* TODO: Is setting confirm event required? */
+  ui_set_confirm_event();
+  return;
 }

--- a/common/interfaces/user_interface/ui_delay.h
+++ b/common/interfaces/user_interface/ui_delay.h
@@ -12,7 +12,6 @@
 #define UI_DELAY_H
 
 #include "ui_common.h"
-#include "ui_events_priv.h"
 #ifdef DEV_BUILD
 #define DELAY_SHORT 500
 #define DELAY_TIME 500

--- a/common/interfaces/user_interface/ui_delay.h
+++ b/common/interfaces/user_interface/ui_delay.h
@@ -12,6 +12,7 @@
 #define UI_DELAY_H
 
 #include "ui_common.h"
+#include "ui_events_priv.h"
 #ifdef DEV_BUILD
 #define DELAY_SHORT 500
 #define DELAY_TIME 500

--- a/common/interfaces/user_interface/ui_input_text.c
+++ b/common/interfaces/user_interface/ui_input_text.c
@@ -167,7 +167,7 @@ void input_text_init(const char *input_list,
  * @brief Clear screen
  *
  */
-void input_text_destructor() {
+void input_text_destructor(void) {
   lv_obj_clean(lv_scr_act());
   if (data != NULL) {
     memzero(data, sizeof(struct Input_Text_Data));

--- a/common/interfaces/user_interface/ui_input_text.h
+++ b/common/interfaces/user_interface/ui_input_text.h
@@ -116,4 +116,16 @@ void input_text_init(const char *input_list,
                      uint8_t min_input_size,
                      INPUT_DATA_TYPE data_type,
                      uint8_t max_input_size);
+
+/**
+ * @brief This API desctructs the objects created when ui_input_text UI
+ * component is used. In most cases, which end gracefully, wherein the user
+ * provides the input from screen or presses cancel button, this desctructor is
+ * called internally. Therefore, this desctructor API is only required if the
+ * application wants to destruct this screen forcefully - which maybe to handle
+ * a P0 event.
+ *
+ */
+void input_text_destructor(void);
+
 #endif    // !UI_INPUT_TEXT_H

--- a/common/interfaces/user_interface/ui_list.c
+++ b/common/interfaces/user_interface/ui_list.c
@@ -79,6 +79,13 @@ void list_init(const char option_list[24][15],
   ASSERT(option_list != NULL);
   ASSERT(heading != NULL);
 
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = malloc(sizeof(struct List_Data));
   obj = malloc(sizeof(struct List_Object));
   ASSERT(data != NULL && obj != NULL);
@@ -115,7 +122,6 @@ void list_init(const char option_list[24][15],
  * @note
  */
 static void list_destructor() {
-  lv_obj_clean(lv_scr_act());
   if (data != NULL) {
     memzero(data, sizeof(struct List_Data));
     free(data);
@@ -239,10 +245,6 @@ static void change_heading() {
  * @note
  */
 static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(options != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -280,6 +282,12 @@ static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(options, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      list_destructor();
+      break;
+    }
     default:
       break;
   }
@@ -301,10 +309,6 @@ static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
  * @note
  */
 static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(back_btn != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -319,13 +323,20 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      list_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(back_btn, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      list_destructor();
+      break;
+    }
     default:
       break;
   }
@@ -347,10 +358,6 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
  * @note
  */
 static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(next_btn != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -364,13 +371,20 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      list_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(next_btn, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      list_destructor();
+      break;
+    }
     default:
       break;
   }

--- a/common/interfaces/user_interface/ui_menu.c
+++ b/common/interfaces/user_interface/ui_menu.c
@@ -236,7 +236,6 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
       lv_obj_clean(lv_scr_act());
-      menu_destructor();
       break;
     }
     case LV_EVENT_DEFOCUSED:

--- a/common/interfaces/user_interface/ui_menu.c
+++ b/common/interfaces/user_interface/ui_menu.c
@@ -83,6 +83,13 @@ void menu_init(const char *option_list[],
                const int number_of_options,
                const char heading[],
                const bool back_button_allowed) {
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = NULL;
   data = malloc(sizeof(struct Menu_Data));
   obj = NULL;
@@ -99,6 +106,7 @@ void menu_init(const char *option_list[],
       data->option_list[i] = (char *)option_list[i];
     }
   }
+
   menu_create();
   LOG_INFO("menu %s, %d", heading, number_of_options);
 }
@@ -117,8 +125,7 @@ void menu_init(const char *option_list[],
  *
  * @note
  */
-static void menu_destructor() {
-  lv_obj_clean(lv_scr_act());
+void menu_destructor() {
   if (data != NULL) {
     memzero(data, sizeof(struct Menu_Data));
     free(data);
@@ -146,10 +153,6 @@ static void menu_destructor() {
  * @note
  */
 static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(options != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       if (lv_btn_get_state(options) == LV_BTN_STATE_PR) {
@@ -182,13 +185,20 @@ static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
+    case LV_EVENT_CLICKED: {
       ui_set_list_event(data->current_index + 1);
-      menu_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(options, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      menu_destructor();
+      break;
+    }
     default:
       break;
   }
@@ -210,10 +220,6 @@ static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
  * @note
  */
 static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-  ASSERT(back_btn != NULL);
-
   switch (event) {
     case LV_EVENT_KEY:
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -224,13 +230,21 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
           break;
       }
       break;
-    case LV_EVENT_CLICKED:
-      ui_mark_event_cancel();
+    case LV_EVENT_CLICKED: {
+      ui_set_cancel_event();
+      lv_obj_clean(lv_scr_act());
       menu_destructor();
       break;
+    }
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(back_btn, LV_BTN_STATE_REL);
       break;
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      menu_destructor();
+      break;
+    }
     default:
       break;
   }

--- a/common/interfaces/user_interface/ui_menu.c
+++ b/common/interfaces/user_interface/ui_menu.c
@@ -83,6 +83,9 @@ void menu_init(const char *option_list[],
                const int number_of_options,
                const char heading[],
                const bool back_button_allowed) {
+  ASSERT(NULL != option_list);
+  ASSERT(NULL != heading);
+
   /* Clear screen before populating any data, this will clear any UI component
    * and it's corresponding objects. Important thing to note here is that the
    * screen will be updated only when lv_task_handler() is called.

--- a/common/interfaces/user_interface/ui_message.c
+++ b/common/interfaces/user_interface/ui_message.c
@@ -88,6 +88,13 @@ static void message_scr_create();
 void message_scr_init(const char *message) {
   ASSERT(message != NULL);
 
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = malloc(sizeof(struct Message_Data));
   obj = malloc(sizeof(struct Message_Object));
 

--- a/common/interfaces/user_interface/ui_message.c
+++ b/common/interfaces/user_interface/ui_message.c
@@ -116,7 +116,6 @@ void message_scr_init(const char *message) {
  * @note
  */
 static void message_scr_destructor() {
-  lv_obj_clean(lv_scr_act());
   if (data != NULL) {
     memzero(data, sizeof(struct Message_Data));
     free(data);
@@ -144,11 +143,12 @@ static void message_scr_destructor() {
  * @note
  */
 static void next_btn_event_handler(lv_obj_t *obj, const lv_event_t event) {
-  ASSERT(data != NULL);
-  ASSERT(obj != NULL);
-
   if (event == LV_EVENT_CLICKED) {
     ui_set_confirm_event();
+    lv_obj_clean(lv_scr_act());
+  } else if (event == LV_EVENT_DELETE) {
+    /* Destruct object and data variables in case the object is being deleted
+     * directly using lv_obj_clean() */
     message_scr_destructor();
   }
 }

--- a/common/interfaces/user_interface/ui_multi_instruction.c
+++ b/common/interfaces/user_interface/ui_multi_instruction.c
@@ -188,8 +188,6 @@ static void multi_instructor_destructor() {
     next_instruction_task = NULL;
   }
 
-  lv_obj_clean(lv_scr_act());
-
   if (data != NULL) {
     memzero(data, sizeof(struct Multi_Instruction_Data));
     free(data);
@@ -219,7 +217,6 @@ static void multi_instructor_destructor() {
  * @note
  */
 void arrow_event_handler(lv_obj_t *instruction, const lv_event_t event) {
-  // TODO: Add assertions
   switch (event) {
     case LV_EVENT_KEY: {
       switch (lv_indev_get_key(ui_get_indev())) {
@@ -261,8 +258,8 @@ void arrow_event_handler(lv_obj_t *instruction, const lv_event_t event) {
       if (data->destruct_on_click == true &&
           ((data->index_of_current_string == data->total_strings - 1) ||
            data->one_cycle_completed)) {
-        multi_instructor_destructor();
         ui_set_confirm_event();
+        lv_obj_clean(lv_scr_act());
       }
       break;
     }
@@ -283,6 +280,7 @@ void arrow_event_handler(lv_obj_t *instruction, const lv_event_t event) {
         lv_task_del(next_instruction_task);
         next_instruction_task = NULL;
       }
+      multi_instructor_destructor();
       break;
     }
     default:
@@ -347,6 +345,13 @@ void multi_instruction_init(const char **arr,
                             const uint8_t count,
                             const uint16_t delay_in_ms,
                             const bool destruct_on_click) {
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
+
   data = NULL;
   data = malloc(sizeof(struct Multi_Instruction_Data));
   obj = NULL;

--- a/common/interfaces/user_interface/ui_scroll_page.c
+++ b/common/interfaces/user_interface/ui_scroll_page.c
@@ -267,8 +267,6 @@ static void page_update_icons(void) {
 }
 
 static void ui_scrollable_destructor(void) {
-  lv_obj_clean(lv_scr_act());
-
   if (NULL != gp_scrollabe_page_data) {
     memzero(gp_scrollabe_page_data, sizeof(scrolling_page_data_t));
     free(gp_scrollabe_page_data);
@@ -286,10 +284,7 @@ static void ui_scrollable_destructor(void) {
 
 static void page_cancel_handler(lv_obj_t *pCancelLvglObj,
                                 const lv_event_t lvglEvent) {
-  ASSERT((NULL != gp_scrollabe_page_data) && (NULL != gp_scrollabe_page_lvgl) &&
-         (NULL != pCancelLvglObj));
-
-  if (lv_obj_get_hidden(pCancelLvglObj)) {
+  if ((LV_EVENT_DELETE != lvglEvent) && (lv_obj_get_hidden(pCancelLvglObj))) {
     return;
   }
 
@@ -314,11 +309,17 @@ static void page_cancel_handler(lv_obj_t *pCancelLvglObj,
     }
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      ui_scrollable_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED: {
       lv_btn_set_state(pCancelLvglObj, LV_BTN_STATE_REL);
+      break;
+    }
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      ui_scrollable_destructor();
       break;
     }
     default: {
@@ -331,10 +332,7 @@ static void page_cancel_handler(lv_obj_t *pCancelLvglObj,
 
 static void page_accept_handler(lv_obj_t *pAcceptLvglObj,
                                 const lv_event_t lvglEvent) {
-  ASSERT((NULL != gp_scrollabe_page_data) && (NULL != gp_scrollabe_page_lvgl) &&
-         (NULL != pAcceptLvglObj));
-
-  if (lv_obj_get_hidden(pAcceptLvglObj)) {
+  if ((LV_EVENT_DELETE != lvglEvent) && (lv_obj_get_hidden(pAcceptLvglObj))) {
     return;
   }
 
@@ -350,11 +348,17 @@ static void page_accept_handler(lv_obj_t *pAcceptLvglObj,
     }
     case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      ui_scrollable_destructor();
+      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED: {
       lv_btn_set_state(pAcceptLvglObj, LV_BTN_STATE_REL);
+      break;
+    }
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      ui_scrollable_destructor();
       break;
     }
     default: {
@@ -367,9 +371,6 @@ static void page_accept_handler(lv_obj_t *pAcceptLvglObj,
 
 static void page_arrow_handler(lv_obj_t *pLvglArrowObject,
                                const lv_event_t lvglEvent) {
-  ASSERT((NULL != gp_scrollabe_page_data) && (NULL != gp_scrollabe_page_lvgl) &&
-         (NULL != pLvglArrowObject));
-
   switch (lvglEvent) {
     case LV_EVENT_KEY: {
       lv_key_t keyPressed = lv_indev_get_key(ui_get_indev());
@@ -430,6 +431,13 @@ static void page_arrow_handler(lv_obj_t *pLvglArrowObject,
       lv_label_set_style(gp_scrollabe_page_lvgl->p_ui_left_arrow_lvgl,
                          LV_LABEL_STYLE_MAIN,
                          &(gp_scrollabe_page_lvgl->ui_arrow_released_style));
+      break;
+    }
+
+    case LV_EVENT_DELETE: {
+      /* Destruct object and data variables in case the object is being deleted
+       * directly using lv_obj_clean() */
+      ui_scrollable_destructor();
       break;
     }
 
@@ -640,6 +648,13 @@ void ui_scrollable_page(const char *p_page_ui_heading,
   if ((NULL == p_page_ui_heading) || (NULL == p_page_ui_body)) {
     return;
   }
+
+  /* Clear screen before populating any data, this will clear any UI component
+   * and it's corresponding objects. Important thing to note here is that the
+   * screen will be updated only when lv_task_handler() is called.
+   * This call will ensure that there is no object present in the currently
+   * active screen in case data from previous screen was not cleared */
+  lv_obj_clean(lv_scr_act());
 
   gp_scrollabe_page_data =
       (scrolling_page_data_t *)malloc(sizeof(scrolling_page_data_t));


### PR DESCRIPTION
This PR adds call to function `lv_obj_clean` from all UI components, to ensure all objects of previously rendered screens are cleaned.

Added handling of event `LV_EVENT_DELETE` in all UI callbacks, which will be responsible for deleting the objects. 

1. By having this fix in place, application can freely render UI components one after the other without having to worry about destructing and previous component
2. For `ui_input_text` this change does not seem to be compatible and therefore, for that particular component, will will have to call the destructor manually