### PR TITLE
fix (build): Reduce time to generate git commit-id

### DIFF
--- a/utilities/cmake/version.cmake
+++ b/utilities/cmake/version.cmake
@@ -12,7 +12,7 @@ if ("${GIT_REV}" STREQUAL "")
     set(GIT_BRANCH "N/A")
 else()
     execute_process(
-        COMMAND bash -c "git diff --quiet --exit-code || echo +"
+        COMMAND sh -c "git diff --quiet --exit-code || echo +"
         OUTPUT_VARIABLE GIT_DIFF)
     execute_process(
         COMMAND git describe --exact-match --tags


### PR DESCRIPTION
The current call to execute_process uses `bash` to execute the test command for checking dirtiness of the git worktree. It takes a long time about a few seconds when executed on windows in git-bash. Replacing with `sh` changes the behaviour and it takes under a second (as expected). This is mostly observed on systems where WSL is enabled in which case, running an instance of bash takes longer.