### PR TITLE
feat (build): Add bash script to auto-generate options file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(${PROJECT})
 # python is needed for compiling proto files using nanopb
 # also for generating & appending firmware signature headers
 find_package( Python3 REQUIRED COMPONENTS Interpreter )
-execute_process(COMMAND sh utilities/generate-protob.sh WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY )
+execute_process(COMMAND sh utilities/proto/generate-protob.sh WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY )
 
 # Populate version.c
 include(utilities/cmake/version.cmake)

--- a/common/proto-options/btc/core.options
+++ b/common/proto-options/btc/core.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/btc/core.proto

--- a/common/proto-options/btc/error.options
+++ b/common/proto-options/btc/error.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/btc/error.proto

--- a/common/proto-options/btc/get_public_key.options
+++ b/common/proto-options/btc/get_public_key.options
@@ -1,0 +1,4 @@
+# Options for file common/cypherock-common/proto/btc/get_public_key.proto
+btc.GetPublicKeyIntiateRequest.wallet_id type:FT_POINTER
+btc.GetPublicKeyIntiateRequest.derivation_path type:FT_POINTER
+btc.GetPublicKeyResultResponse.public_key type:FT_POINTER

--- a/common/proto-options/btc/get_xpubs.options
+++ b/common/proto-options/btc/get_xpubs.options
@@ -1,0 +1,5 @@
+# Options for file common/cypherock-common/proto/btc/get_xpubs.proto
+btc.GetXpubDerivationPath.path type:FT_POINTER
+btc.GetXpubsIntiateRequest.wallet_id type:FT_POINTER
+btc.GetXpubsIntiateRequest.derivation_paths type:FT_POINTER
+btc.GetXpubsResultResponse.xpubs type:FT_POINTER

--- a/common/proto-options/btc/sign_txn.options
+++ b/common/proto-options/btc/sign_txn.options
@@ -1,0 +1,8 @@
+# Options for file common/cypherock-common/proto/btc/sign_txn.proto
+btc.SignTxnInitiateRequest.walletId type:FT_POINTER
+btc.SignTxnInitiateRequest.derivationPath type:FT_POINTER
+btc.SignTxnInputResponse.prev_txn type:FT_POINTER
+btc.SignTxnInputResponse.prev_txn_hash type:FT_POINTER
+btc.SignTxnInputResponse.scriptPubKey type:FT_POINTER
+btc.SignTxnOutputResponse.scriptPubKey type:FT_POINTER
+btc.SignTxnSignatureResponse.signature type:FT_POINTER

--- a/common/proto-options/common.options
+++ b/common/proto-options/common.options
@@ -1,0 +1,2 @@
+# Options for file common/cypherock-common/proto/common.proto
+common.ChunkResponse.chunk type:FT_POINTER

--- a/common/proto-options/core.options
+++ b/common/proto-options/core.options
@@ -1,0 +1,2 @@
+# Options for file common/cypherock-common/proto/core.proto
+core.Command.data type:FT_POINTER

--- a/common/proto-options/error.options
+++ b/common/proto-options/error.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/error.proto

--- a/common/proto-options/evm/common.options
+++ b/common/proto-options/evm/common.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/evm/common.proto

--- a/common/proto-options/evm/core.options
+++ b/common/proto-options/evm/core.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/evm/core.proto

--- a/common/proto-options/evm/get_public_keys.options
+++ b/common/proto-options/evm/get_public_keys.options
@@ -1,0 +1,6 @@
+# Options for file common/cypherock-common/proto/evm/get_public_keys.proto
+evm.GetPublicKeysDerivationPath.path type:FT_POINTER
+evm.GetPublicKeysIntiateRequest.wallet_id type:FT_POINTER
+evm.GetPublicKeysIntiateRequest.derivation_paths type:FT_POINTER
+evm.GetPublicKeysIntiateRequest.chain_id type:FT_POINTER
+evm.GetPublicKeysResultResponse.public_keys type:FT_POINTER

--- a/common/proto-options/evm/sign_msg.options
+++ b/common/proto-options/evm/sign_msg.options
@@ -1,0 +1,9 @@
+# Options for file common/cypherock-common/proto/evm/sign_msg.proto
+evm.SignTypedDataNode.name type:FT_POINTER
+evm.SignTypedDataNode.struct_name type:FT_POINTER
+evm.SignTypedDataNode.children type:FT_POINTER
+evm.SignMsgInitiateRequest.walletId type:FT_POINTER
+evm.SignMsgInitiateRequest.derivationPath type:FT_POINTER
+evm.SignMsgSignatureResponse.r type:FT_POINTER
+evm.SignMsgSignatureResponse.s type:FT_POINTER
+evm.SignMsgSignatureResponse.v type:FT_POINTER

--- a/common/proto-options/evm/sign_txn.options
+++ b/common/proto-options/evm/sign_txn.options
@@ -1,0 +1,7 @@
+# Options for file common/cypherock-common/proto/evm/sign_txn.proto
+evm.SignTxnInitiateRequest.walletId type:FT_POINTER
+evm.SignTxnInitiateRequest.derivationPath type:FT_POINTER
+evm.SignTxnInitiateRequest.chain_id type:FT_POINTER
+evm.SignTxnSignatureResponse.r type:FT_POINTER
+evm.SignTxnSignatureResponse.s type:FT_POINTER
+evm.SignTxnSignatureResponse.v type:FT_POINTER

--- a/common/proto-options/manager/auth_card.options
+++ b/common/proto-options/manager/auth_card.options
@@ -1,0 +1,5 @@
+# Options for file common/cypherock-common/proto/manager/auth_card.proto
+manager.AuthCardChallengeRequest.challenge type:FT_POINTER
+manager.AuthCardSerialSigResponse.serial type:FT_POINTER
+manager.AuthCardSerialSigResponse.signature type:FT_POINTER
+manager.AuthCardChallengeSigResponse.signature type:FT_POINTER

--- a/common/proto-options/manager/auth_device.options
+++ b/common/proto-options/manager/auth_device.options
@@ -1,0 +1,9 @@
+# Options for file common/cypherock-common/proto/manager/auth_device.proto
+manager.AuthDeviceChallengeRequest.challenge type:FT_POINTER
+manager.AuthDeviceSerialSigResponse.postfix1 type:FT_POINTER
+manager.AuthDeviceSerialSigResponse.postfix2 type:FT_POINTER
+manager.AuthDeviceSerialSigResponse.serial type:FT_POINTER
+manager.AuthDeviceSerialSigResponse.signature type:FT_POINTER
+manager.AuthDeviceChallengeSigResponse.postfix1 type:FT_POINTER
+manager.AuthDeviceChallengeSigResponse.postfix2 type:FT_POINTER
+manager.AuthDeviceChallengeSigResponse.signature type:FT_POINTER

--- a/common/proto-options/manager/core.options
+++ b/common/proto-options/manager/core.options
@@ -1,0 +1,1 @@
+# Options for file common/cypherock-common/proto/manager/core.proto

--- a/common/proto-options/manager/get_device_info.options
+++ b/common/proto-options/manager/get_device_info.options
@@ -1,0 +1,3 @@
+# Options for file common/cypherock-common/proto/manager/get_device_info.proto
+manager.GetDeviceInfoResultResponse.device_serial type:FT_POINTER
+manager.GetDeviceInfoResultResponse.applet_list type:FT_POINTER

--- a/common/proto-options/manager/get_logs.options
+++ b/common/proto-options/manager/get_logs.options
@@ -1,0 +1,2 @@
+# Options for file common/cypherock-common/proto/manager/get_logs.proto
+manager.GetLogsDataResponse.data type:FT_POINTER

--- a/common/proto-options/manager/get_wallets.options
+++ b/common/proto-options/manager/get_wallets.options
@@ -1,0 +1,4 @@
+# Options for file common/cypherock-common/proto/manager/get_wallets.proto
+manager.WalletItem.id type:FT_POINTER
+manager.WalletItem.name type:FT_POINTER
+manager.GetWalletsResultResponse.wallet_list type:FT_POINTER

--- a/common/proto-options/manager/train_user.options
+++ b/common/proto-options/manager/train_user.options
@@ -1,0 +1,4 @@
+# Options for file common/cypherock-common/proto/manager/train_user.proto
+manager.ExistingWalletItem.id type:FT_POINTER
+manager.ExistingWalletItem.name type:FT_POINTER
+manager.TrainUserResultResponse.existing_wallet_list type:FT_POINTER

--- a/utilities/proto/gen-options.sh
+++ b/utilities/proto/gen-options.sh
@@ -10,10 +10,17 @@ function wrong_dir {
 test -d common/cypherock-common/proto || wrong_dir
 
 # Make sure all directories exist for the proto-options
-test -d common/proto-options/ || mkdir common/proto-options/
-test -d common/proto-options/manager || mkdir common/proto-options/manager
-test -d common/proto-options/btc || mkdir common/proto-options/btc
-test -d common/proto-options/evm || mkdir common/proto-options/evm
+source_dir="common/cypherock-common/proto"
+destination_dir="common/proto-options/"
+
+mkdir -p "$destination_dir"
+
+# Find all directories in the source directory
+find "$source_dir" -type d -print0 | while IFS= read -r -d '' dir; do
+    # Create corresponding directories in the destination directory
+    rel_path="${dir#$source_dir}"
+    mkdir -p "$destination_dir/$rel_path"
+done
 
 FILES=$(find common/cypherock-common/proto -name '*.proto' | cut -f -1 -d "." )
 PWD="$(pwd)"

--- a/utilities/proto/gen-options.sh
+++ b/utilities/proto/gen-options.sh
@@ -9,6 +9,12 @@ function wrong_dir {
 
 test -d common/cypherock-common/proto || wrong_dir
 
+# Make sure all directories exist for the proto-options
+test -d common/proto-options/ || mkdir common/proto-options/
+test -d common/proto-options/manager || mkdir common/proto-options/manager
+test -d common/proto-options/btc || mkdir common/proto-options/btc
+test -d common/proto-options/evm || mkdir common/proto-options/evm
+
 FILES=$(find common/cypherock-common/proto -name '*.proto' | cut -f -1 -d "." )
 PWD="$(pwd)"
 
@@ -44,7 +50,7 @@ function search_line {
 
 for FILE in ${FILES}; do
   PROTO_FILE="${PWD}/${FILE}.proto"
-  OPT_FILE="${PWD}/${FILE}.options"
+  OPT_FILE="${PWD}/"${FILE/"cypherock-common/proto"/proto-options}".options"
   echo "# Options for file ${FILE}.proto" > "${OPT_FILE}"
   while IFS= read -r line; do
     search_line "${line}"

--- a/utilities/proto/gen_options.sh
+++ b/utilities/proto/gen_options.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#set -x
+
+function wrong_dir {
+  echo "Run from root directory"
+  exit 1
+}
+
+test -d common/cypherock-common/proto || wrong_dir
+
+FILES=$(find common/cypherock-common/proto -name '*.proto' | cut -f -1 -d "." )
+PWD="$(pwd)"
+
+PKG_PATTERN="^ *(package) (.*) *;"
+MSG_PATTERN="^ *(message) (.*) {"
+MEMBER_PATTERN="^ *(repeated )?(string|bytes)?(.*){1} (.*) ="
+
+# Below is an optimized version of above pattern. But is not supported by bash
+# PKG_PATTERN="^ *(package) (\S*) *;"
+# MSG_PATTERN="^ *(message) (\S*) {"
+# MEMBER_PATTERN="^ *(repeated )?(string|bytes)?(\S*){1} (\S*) ="
+
+
+PKG=""
+MSG=""
+MEMBER=""
+PROTO_FILE=""
+OPT_FILE=""
+
+function search_line {
+  LINE="${1}"
+  if [[ "${LINE}" =~ $PKG_PATTERN ]]; then
+    PKG=${BASH_REMATCH[2]}
+  elif [[ "${LINE}" =~ $MSG_PATTERN ]]; then
+    MSG=${BASH_REMATCH[2]}
+  elif [[ "${LINE}" =~ $MEMBER_PATTERN ]]; then
+    MEMBER=${BASH_REMATCH[4]}
+    if [[ ! ${BASH_REMATCH[1]} = "" ]] || [[ ! ${BASH_REMATCH[2]} = "" ]]; then
+      echo "${PKG}.${MSG}.${MEMBER} type:FT_POINTER" >> "${OPT_FILE}"
+    fi
+  fi
+}
+
+for FILE in ${FILES}; do
+  PROTO_FILE="${PWD}/${FILE}.proto"
+  OPT_FILE="${PWD}/${FILE}.options"
+  echo "# Options for file ${FILE}.proto" > "${OPT_FILE}"
+  while IFS= read -r line; do
+    search_line "${line}"
+  done < "${PROTO_FILE}"
+done

--- a/utilities/proto/generate-protob.sh
+++ b/utilities/proto/generate-protob.sh
@@ -8,6 +8,7 @@ NANOPB_GEN="$(pwd)/vendor/nanopb/generator/nanopb_generator.py"
 PYTHON_VERSION="$(python --version)" || exit 1
 OUTPUT_DIR="$(pwd)/generated/proto"
 PROTO_SRC="$(pwd)/common/cypherock-common/proto"
+OPTIONS_DIR="$(pwd)/common/proto-options/"
 
 test -d "${PROTO_SRC}"
 test -f "${NANOPB_GEN}"
@@ -23,4 +24,4 @@ cd "${PROTO_SRC}"
 # btc.error.proto) as it would result into a collision.
 # By using <> format instead of "proto/" helps because in future, relocation
 # of generated files would not require updating this parameter.
-python "${NANOPB_GEN}" -q --generated-include-format "#include <%s>" --proto-path="${PROTO_SRC}" $(find "${PROTO_SRC}" -name "*.proto") --output-dir="${OUTPUT_DIR}" --c-style
+python "${NANOPB_GEN}" -q --generated-include-format "#include <%s>" --proto-path="${PROTO_SRC}" --options-path="${OPTIONS_DIR}"  $(find "${PROTO_SRC}" -name "*.proto") --output-dir="${OUTPUT_DIR}" --c-style


### PR DESCRIPTION
To integrate some protobuf structures in our project, we need to configure options for the nanopb compiler. 
This PR generates the options files for each proto file and configures nanopb compiler to use these options files

Of course, these options file will be modified later as per usage.