### PR TITLE
refactor: Add new api in engine to run single step

### DIFF
--- a/common/core/flow_engine.h
+++ b/common/core/flow_engine.h
@@ -161,6 +161,16 @@ bool engine_delete_current_flow_step(engine_ctx_t *ctx);
  * @param ctx Pointer to data of type engine_ctx_t which holds the correct data
  * for the buffer
  */
-void engine_run(engine_ctx_t *ctx);
+void engine_run_flow(engine_ctx_t *ctx);
+
+/**
+ * @brief This API runs a particular step of the flow. This flow may or may not
+ * be initiated from an engine context.
+ *
+ * @param ctx The engine context from which it was invoked. It can be NULL in
+ * case it's a single step flow.
+ * @param step Flow step pointer depicting the step that needs to be executed.
+ */
+void engine_run_step(engine_ctx_t *ctx, flow_step_t *step);
 
 #endif /* FLOW_ENGINE_H */

--- a/src/main.c
+++ b/src/main.c
@@ -153,7 +153,7 @@ int main(void) {
   logo_scr_init(2000);
   while (1) {
     engine_ctx_t *main_engine_ctx = get_core_flow_ctx();
-    engine_run(main_engine_ctx);
+    engine_run_flow(main_engine_ctx);
   }
 #else /* RUN_ENGINE */
 

--- a/tests/common/core/flow_engine_tests.c
+++ b/tests/common/core/flow_engine_tests.c
@@ -234,7 +234,7 @@ TEST(flow_engine_tests, engine_use_case_test) {
 #endif
 
   // Run the engine until it reaches the last step
-  engine_run(&flow_list);
+  engine_run_flow(&flow_list);
 
 #if USE_SIMULATOR == 1
   TEST_ASSERT_FALSE(callback_test.p0_event);


### PR DESCRIPTION
This change is done to enable re-use of `engine_run_step` from different locations, where creating a buffer is overhead since there is only a single step in the flow