### PR TITLE
fix (ui): Remove recursive event callbacks

### DIFF
--- a/common/interfaces/user_interface/ui_address.c
+++ b/common/interfaces/user_interface/ui_address.c
@@ -173,7 +173,6 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
       break;
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:
@@ -223,7 +222,6 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:

--- a/common/interfaces/user_interface/ui_confirmation.c
+++ b/common/interfaces/user_interface/ui_confirmation.c
@@ -146,7 +146,6 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:
@@ -193,7 +192,6 @@ static void cancel_btn_event_handler(lv_obj_t *cancel_btn,
       break;
     case LV_EVENT_CLICKED:
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(cancel_btn, LV_BTN_STATE_REL);

--- a/common/interfaces/user_interface/ui_input_mnemonics.c
+++ b/common/interfaces/user_interface/ui_input_mnemonics.c
@@ -386,7 +386,6 @@ static void center_event_handler(lv_obj_t *center, const lv_event_t event) {
       } else if (data->state == SHOWING_SUGGESTIONS) {
         data->state = EXIT;
         ui_set_list_event(data->index);
-        lv_obj_clean(lv_scr_act());
         return;
       } else {
         // shouldn't come here

--- a/common/interfaces/user_interface/ui_list.c
+++ b/common/interfaces/user_interface/ui_list.c
@@ -328,7 +328,6 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:
@@ -376,7 +375,6 @@ static void next_btn_event_handler(lv_obj_t *next_btn, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:

--- a/common/interfaces/user_interface/ui_menu.c
+++ b/common/interfaces/user_interface/ui_menu.c
@@ -190,7 +190,6 @@ static void options_event_handler(lv_obj_t *options, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_list_event(data->current_index + 1);
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:
@@ -235,7 +234,6 @@ static void back_btn_event_handler(lv_obj_t *back_btn, const lv_event_t event) {
       break;
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED:

--- a/common/interfaces/user_interface/ui_message.c
+++ b/common/interfaces/user_interface/ui_message.c
@@ -152,7 +152,6 @@ static void message_scr_destructor() {
 static void next_btn_event_handler(lv_obj_t *obj, const lv_event_t event) {
   if (event == LV_EVENT_CLICKED) {
     ui_set_confirm_event();
-    lv_obj_clean(lv_scr_act());
   } else if (event == LV_EVENT_DELETE) {
     /* Destruct object and data variables in case the object is being deleted
      * directly using lv_obj_clean() */

--- a/common/interfaces/user_interface/ui_multi_instruction.c
+++ b/common/interfaces/user_interface/ui_multi_instruction.c
@@ -286,7 +286,6 @@ void arrow_event_handler(lv_obj_t *instruction, const lv_event_t event) {
           ((data->index_of_current_string == data->total_strings - 1) ||
            data->one_cycle_completed)) {
         ui_set_confirm_event();
-        lv_obj_clean(lv_scr_act());
       }
       break;
     }

--- a/common/interfaces/user_interface/ui_scroll_page.c
+++ b/common/interfaces/user_interface/ui_scroll_page.c
@@ -309,7 +309,6 @@ static void page_cancel_handler(lv_obj_t *pCancelLvglObj,
     }
     case LV_EVENT_CLICKED: {
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED: {
@@ -348,7 +347,6 @@ static void page_accept_handler(lv_obj_t *pAcceptLvglObj,
     }
     case LV_EVENT_CLICKED: {
       ui_set_confirm_event();
-      lv_obj_clean(lv_scr_act());
       break;
     }
     case LV_EVENT_DEFOCUSED: {

--- a/common/interfaces/user_interface/ui_skip_instruction.c
+++ b/common/interfaces/user_interface/ui_skip_instruction.c
@@ -120,7 +120,6 @@ static void skip_btn_event_handler(lv_obj_t *skip_btn, const lv_event_t event) {
   switch (event) {
     case LV_EVENT_CLICKED:
       ui_set_cancel_event();
-      lv_obj_clean(lv_scr_act());
       break;
     case LV_EVENT_DEFOCUSED:
       lv_btn_set_state(skip_btn, LV_BTN_STATE_REL);

--- a/common/interfaces/user_interface/ui_text_slideshow.c
+++ b/common/interfaces/user_interface/ui_text_slideshow.c
@@ -132,7 +132,6 @@ static void event_handler(lv_obj_t *obj, const lv_event_t event) {
     case LV_EVENT_CLICKED: {
       if (data->one_cycle_completed && data->destruct_on_click) {
         ui_set_confirm_event();
-        lv_obj_clean(lv_scr_act());
       }
       break;
     }


### PR DESCRIPTION
The current strategy of calling `lv_obj_clean(lv_scr_act())` from inside of event handlers leads to recursive event handler calls. This is because the lv_obj_clean() does in-place object deletion hierarchically. Objects are deleted even before the event handler exits.

Additionally, the lvgl events handling appears to be unsafe for deleted object references. This means if lvgl has events E1 & E2, then calling lv_obj_clean() when E1 is being handled leads to app crashes when as the object already deleted before callback for E2 is called.

Side-effects
1. Faster transitions between two screen renders (blank screens will stay for a shorter duration).
2. Frozen screens will be show instead of blank screens (between two successive calls to `lv_task_handler`)