### PR TITLE
Fix core apis: usb and application status

### DIFF
--- a/common/core/status_api.c
+++ b/common/core/status_api.c
@@ -108,8 +108,11 @@ void core_status_set_idle_state(core_device_idle_state_t idle_state) {
   if (CORE_DEVICE_IDLE_STATE_IDLE == core_status.device_idle_state)
     comm_reset_interface();
 
-  core_status.abort_disabled =
-      (CORE_DEVICE_IDLE_STATE_USB == core_status.device_idle_state);
+  if (CORE_DEVICE_IDLE_STATE_USB == core_status.device_idle_state) {
+    core_status.abort_disabled = false;
+  } else {
+    core_status.abort_disabled = true;
+  }
   return;
 }
 

--- a/common/interfaces/desktop_app_interface/usb_api.c
+++ b/common/interfaces/desktop_app_interface/usb_api.c
@@ -215,10 +215,6 @@ void usb_send_data(const uint32_t command_type,
 }
 
 void usb_send_msg(const uint8_t *msg, const uint32_t size) {
-  if (NULL == msg || 0 == size) {
-    return;
-  }
-
   uint8_t usb_irq_enable = NVIC_GetEnableIRQ(OTG_FS_IRQn);
   LOG_SWV("%s: %ld\n", __func__, size);
 
@@ -247,7 +243,7 @@ void usb_send_msg(const uint8_t *msg, const uint32_t size) {
   comm_io_buffer[2] = (size >> 8) & 0xFF;
   comm_io_buffer[3] = size & 0xFF;
 
-  if (0 < size) {
+  if (0 < size && NULL != msg) {
     // copy app message into payload buffer after core-msg
     // COMM_SZ_RESERVED_SPACE + core_msg_len
     memcpy(comm_io_buffer + COMM_SZ_RESERVED_SPACE + stream.bytes_written,


### PR DESCRIPTION
Fixes

#### 1. Current usb_send_msg exits on empty msg
The current behavior is not consistent with the expectations of the API. Because, if the application sends 0-sized messages, the current API will do an early exit which leads to unserved USB events. This can cause issues in the application state and hence out of sync with the host application.

#### 2. Correct abort flag assignment case