### PR TITLE
fix (core): Optimize usage of bip39 wordlist

### DIFF
--- a/common/interfaces/user_interface/ui_input_mnemonics.c
+++ b/common/interfaces/user_interface/ui_input_mnemonics.c
@@ -58,7 +58,6 @@
  */
 #include "ui_input_mnemonics.h"
 
-#include "bip39_english.h"
 #include "ui_events_priv.h"
 static void ui_mnem_create();
 static void refresh_screen_texts();
@@ -127,7 +126,8 @@ int get_first_index(const char word[3]) {
   ASSERT(word != NULL);
 
   for (int i = 0; i <= 2047; i++) {
-    if ((word[0] + 32 == wordlist[i][0]) && (word[1] + 32 == wordlist[i][1])) {
+    if ((word[0] + 32 == mnemonic_get_word(i)[0]) &&
+        (word[1] + 32 == mnemonic_get_word(i)[1])) {
       return i;
     }
   }
@@ -145,7 +145,8 @@ int get_last_index(const char word[3]) {
   ASSERT(word != NULL);
 
   for (int i = 2047; i >= 0; --i) {
-    if ((word[0] + 32 == wordlist[i][0]) && (word[1] + 32 == wordlist[i][1])) {
+    if ((word[0] + 32 == mnemonic_get_word(i)[0]) &&
+        (word[1] + 32 == mnemonic_get_word(i)[1])) {
       return i;
     }
   }
@@ -174,11 +175,11 @@ static void second_char_init() {
   int16_t high = 0;
 
   for (int i = 0; i <= 2047; i++) {
-    if (data->text_entered[0] + 32 == wordlist[i][0]) {
+    if (data->text_entered[0] + 32 == mnemonic_get_word(i)[0]) {
       if (low < 0)
-        low = wordlist[i][1] - 'a';
-      data->second_char_ind |= 1 << (wordlist[i][1] - 'a');
-      high = wordlist[i][1] - 'a';
+        low = mnemonic_get_word(i)[1] - 'a';
+      data->second_char_ind |= 1 << (mnemonic_get_word(i)[1] - 'a');
+      high = mnemonic_get_word(i)[1] - 'a';
     }
   }
 
@@ -554,7 +555,7 @@ static void refresh_screen_texts() {
     lv_label_set_text(obj->text_entered, data->text_entered);
   } else if (data->state == SHOWING_SUGGESTIONS) {
     lv_label_set_text(lv_obj_get_child(obj->center_screen, NULL),
-                      wordlist[data->index]);
+                      mnemonic_get_word(data->index));
     lv_label_set_text(obj->text_entered, data->text_entered);
   }
 }

--- a/src/level_four/core/controller/add_coin_controller.c
+++ b/src/level_four/core/controller/add_coin_controller.c
@@ -59,7 +59,6 @@
  */
 #include "bip32.h"
 #include "bip39.h"
-#include "bip39_english.h"
 #include "board.h"
 #include "btc.h"
 #include "communication.h"

--- a/src/level_four/core/controller/initial_device_provision_contoller.c
+++ b/src/level_four/core/controller/initial_device_provision_contoller.c
@@ -58,7 +58,6 @@
  ******************************************************************************
  */
 #include "bip32.h"
-#include "bip39_english.h"
 #include "btc.h"
 #include "communication.h"
 #include "controller_level_four.h"

--- a/src/level_three/add_wallet/controller/controller_arbitrary_data.c
+++ b/src/level_three/add_wallet/controller/controller_arbitrary_data.c
@@ -58,7 +58,6 @@
  ******************************************************************************
  */
 #include "bip39.h"
-#include "bip39_english.h"
 #include "card_action_controllers.h"
 #include "constant_texts.h"
 #include "controller_add_wallet.h"
@@ -85,7 +84,7 @@ static void restore_wallet_enter_mnemonics_flow_controller() {
         wallet_credential_data.mnemonics[flow_level.level_four - 1],
         sizeof(wallet_credential_data.mnemonics[flow_level.level_four - 1]),
         "%s",
-        wordlist[flow_level.screen_input.list_choice]);
+        mnemonic_get_word(flow_level.screen_input.list_choice));
     flow_level.level_four++;
   } else {
     flow_level.level_three++;

--- a/src/level_three/add_wallet/controller/controller_restore_wallet.c
+++ b/src/level_three/add_wallet/controller/controller_restore_wallet.c
@@ -58,7 +58,6 @@
  ******************************************************************************
  */
 #include "bip39.h"
-#include "bip39_english.h"
 #include "card_action_controllers.h"
 #include "constant_texts.h"
 #include "controller_add_wallet.h"
@@ -86,7 +85,7 @@ static void restore_wallet_enter_mnemonics_flow_controller() {
         wallet_credential_data.mnemonics[flow_level.level_four - 1],
         sizeof(wallet_credential_data.mnemonics[flow_level.level_four - 1]),
         "%s",
-        wordlist[flow_level.screen_input.list_choice]);
+        mnemonic_get_word(flow_level.screen_input.list_choice));
     flow_level.level_four++;
   } else {
     flow_level.level_three = RESTORE_WALLET_VERIFY_MNEMONICS_INSTRUCTION;

--- a/src/level_three/add_wallet/tasks/tasks_new_wallet.c
+++ b/src/level_three/add_wallet/tasks/tasks_new_wallet.c
@@ -56,7 +56,6 @@
  *
  ******************************************************************************
  */
-#include "bip39_english.h"
 #include "constant_texts.h"
 #include "controller_main.h"
 #include "tasks.h"


### PR DESCRIPTION
The import of static list of string array unneccesararily bloats the binary size. Replace the import with provided api function. This reduces the size of .text section from 547108 bytes to 530836 bytes (on windows build environment). A difference of 16272 bytes (~16 kB).