### PR TITLE
chore(build): Fix vscode cmake issue for configure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
 
 {
     "cmake.configureSettings": {
-        "CMAKE_BUILD_PLATFORM":"Device"
+        "CMAKE_BUILD_PLATFORM":"Device",
+        "FIRMWARE_TYPE":"Main",
     },
     "files.associations": {
         "*.html": "html",


### PR DESCRIPTION
VS code's cmake extension omits FIRMWARE_TYPE as an argument when compiling, this is a fix.