### PR TITLE
fix: Card training buzzer and state correction

### DIFF
--- a/apps/manager_app/card_training.c
+++ b/apps/manager_app/card_training.c
@@ -177,4 +177,5 @@ void manager_card_training(manager_query_t *query) {
   snprintf(msg, sizeof(msg), UI_TEXT_CARD_TAPPED, pair_result.card_number);
   delay_scr_init(msg, DELAY_TIME);
   // TODO: Show wallets if exist and wait for user acceptance on via app
+  onboarding_set_step_done(MANAGER_ONBOARDING_STEP_CARD_CHECKUP);
 }

--- a/src/card_operations/check_pairing.c
+++ b/src/card_operations/check_pairing.c
@@ -126,10 +126,10 @@ card_error_type_e card_check_pairing(check_pairing_result_t *result) {
   card_operation_data_t operation_data = {{0}, NULL, 0};
   init_tap_card_data(&operation_data.nfc_data);
   status = card_initialize_applet(&operation_data);
-  buzzer_start(100);
   nfc_deselect_card();
 
   if (CARD_OPERATION_SUCCESS == status) {
+    buzzer_start(100);
     result->card_number =
         decode_card_number(operation_data.nfc_data.tapped_card);
     memcpy(
@@ -139,13 +139,6 @@ card_error_type_e card_check_pairing(check_pairing_result_t *result) {
       result->is_paired = false;
     } else {
       result->is_paired = true;
-    }
-  } else {
-    LOG_SWV("%s (%d):", __func__, __LINE__);
-    LOG_CRITICAL("COCP %04X\n", operation_data.nfc_data.status);
-    if (NULL != operation_data.error_message) {
-      message_scr_init(operation_data.error_message);
-      get_events(EVENT_CONFIG_USB, MAX_INACTIVITY_TIMEOUT);
     }
   }
   return status;


### PR DESCRIPTION
The buzzer should make a sound in the success case only. Abort from the host should not trigger the buzzer. Also, card operation abort errors are now handled globally hence its handling is being removed. Update the card training state to the flash.