### PR TITLE
fix (app): Add hard delay screen at flow completion

### DIFF
--- a/apps/btc_app/get_xpub.c
+++ b/apps/btc_app/get_xpub.c
@@ -281,7 +281,7 @@ void btc_get_xpub(btc_query_t *query) {
                  sizeof(btc_get_xpub_derivation_path_t)][XPUB_SIZE] = {0};
 
   core_status_set_flow_status(BTC_GET_XPUBS_STATUS_CARD);
-  instruction_scr_init(ui_text_processing, NULL);
+  delay_scr_init(ui_text_processing, DELAY_SHORT);
   if (true == one_shot_xpub_generate(init_req->derivation_paths,
                                      seed,
                                      xpub_list,

--- a/apps/manager_app/get_logs.c
+++ b/apps/manager_app/get_logs.c
@@ -216,7 +216,7 @@ void manager_get_logs(manager_query_t *query) {
   }
 
   result.get_logs.which_response = MANAGER_GET_LOGS_RESPONSE_LOGS_TAG;
-  instruction_scr_init(ui_text_sending_logs, NULL);
+  delay_scr_init(ui_text_sending_logs, DELAY_SHORT);
   core_status_set_flow_status(MANAGER_GET_LOGS_STATUS_USER_CONFIRMED);
   if (true == send_logs(query, &result)) {
     // logs sent successfully, display "Logs sent"


### PR DESCRIPTION
All the screens conveying background processing/computation (eg. "Processing...", "Sending logs...", etc. had a possibility of showing glitch behaviour if the processing time is very small. The recent proting of the flows dropped this subtle requirement.