### PR TITLE
refactor (core): Add screen type to core_user_confirmation

### DIFF
--- a/apps/btc_app/get_xpub.c
+++ b/apps/btc_app/get_xpub.c
@@ -270,7 +270,7 @@ void btc_get_xpub(btc_query_t *query) {
   wallet_name = (const char *)get_wallet_name(wallet_index);
   snprintf(msg, sizeof(msg), "Add Bitcoin to %s", wallet_name);
   // Take user consent to export xpub for the wallet
-  if (!core_user_confirmation(msg, btc_send_error)) {
+  if (!core_user_confirmation(NULL, msg, CONFIRMATION_SCREEN, btc_send_error)) {
     return;
   }
   core_status_set_flow_status(BTC_GET_XPUBS_STATUS_CONFIRM);

--- a/apps/manager_app/device_authentication.c
+++ b/apps/manager_app/device_authentication.c
@@ -242,7 +242,9 @@ static device_auth_state_e sign_serial_handler(const manager_query_t *query) {
   switch (request_type) {
     case MANAGER_AUTH_DEVICE_REQUEST_INITIATE_TAG: {
       if (is_device_authenticated() &&
-          !core_user_confirmation(ui_text_start_device_verification,
+          !core_user_confirmation(NULL,
+                                  ui_text_start_device_verification,
+                                  CONFIRMATION_SCREEN,
                                   manager_send_error)) {
         // re-authentication denied by user
         next_state = FLOW_COMPLETE;

--- a/apps/manager_app/get_logs.c
+++ b/apps/manager_app/get_logs.c
@@ -211,7 +211,10 @@ void manager_get_logs(manager_query_t *query) {
 
   manager_result_t result = init_manager_result(MANAGER_RESULT_GET_LOGS_TAG);
   if (!check_which_request(query, MANAGER_GET_LOGS_REQUEST_INITIATE_TAG) ||
-      !core_user_confirmation(ui_text_send_logs_prompt, manager_send_error)) {
+      !core_user_confirmation(NULL,
+                              ui_text_send_logs_prompt,
+                              CONFIRMATION_SCREEN,
+                              manager_send_error)) {
     return;
   }
 

--- a/common/core/ui_core_confirm.c
+++ b/common/core/ui_core_confirm.c
@@ -98,8 +98,18 @@
  * GLOBAL FUNCTIONS
  *****************************************************************************/
 
-bool core_user_confirmation(const char *msg, ui_core_rejection_cb *reject_cb) {
-  confirm_scr_init(msg);
+bool core_user_confirmation(const char *title,
+                            const char *body,
+                            ui_type_e type,
+                            ui_core_rejection_cb *reject_cb) {
+  if (SCROLL_PAGE_SCREEN == type) {
+    ui_scrollable_page(title, body, MENU_SCROLL_HORIZONTAL, false);
+  } else if (CONFIRMATION_SCREEN == type) {
+    confirm_scr_init(body);
+  } else {
+    // unexpected ui_type_e received; should never reach here
+    return false;
+  }
   evt_status_t events = get_events(EVENT_CONFIG_UI, MAX_INACTIVITY_TIMEOUT);
   if (true == events.p0_event.flag) {
     // core will handle p0 events, exit now

--- a/common/core/ui_core_confirm.h
+++ b/common/core/ui_core_confirm.h
@@ -23,6 +23,11 @@
  * TYPEDEFS
  *****************************************************************************/
 
+typedef enum {
+  CONFIRMATION_SCREEN,
+  SCROLL_PAGE_SCREEN,
+} ui_type_e;
+
 typedef void(ui_core_rejection_cb)(pb_size_t which_error, uint32_t error_code);
 
 /*****************************************************************************
@@ -35,20 +40,26 @@ typedef void(ui_core_rejection_cb)(pb_size_t which_error, uint32_t error_code);
 
 /**
  * @brief The function confirms the user intention for initiating log export
- * @details The function will render a confirmation screen (confirm_scr_init)
+ * @details The function will render a confirmation screen based on ui_type_e
  * and listen for events. The function will only listen to an UI event and
  * handles UI and P0 event. In case of a P0 event, the function will simply
  * return false and do an early exit. In case if the user denied the permission
  * by selecting cancel, the function executes the provided callback if it exists
- * to the host manager app.
+ * to the host manager app. The function only supports 2 screen types namely
+ * confirm_scr_init, ui_scrollable_page
  *
+ * @param title Reference to the title for the screen
  * @param msg Reference to the message to display against user confirmation
+ * @param type Type of the UI screen to be displayed
  * @param reject_cb Callback to execute if user rejected
  *
  * @return bool Indicating if the user confirmation succeeded.
  * @retval true The user confirmed his/her intention to export logs
  * @retval false The user either rejected the prompt or a P0 event occurred
  */
-bool core_user_confirmation(const char *msg, ui_core_rejection_cb *reject_cb);
+bool core_user_confirmation(const char *title,
+                            const char *msg,
+                            ui_type_e type,
+                            ui_core_rejection_cb *reject_cb);
 
 #endif


### PR DESCRIPTION
The current implementation for `core_user_confirmation` only covers the specific use-case for confirm_scr_init UI. Other screen types can also generate the same events and also the same handling. Adding support for those UI screens will consolidate duplicated logic from the application.