### PR TITLE
refactor: Add bitcoin derivation path guard

### DIFF
--- a/apps/btc_app/btc_helpers.c
+++ b/apps/btc_app/btc_helpers.c
@@ -128,7 +128,7 @@ bool btc_derivation_path_guard(const uint32_t *path, uint32_t depth) {
   // common checks for xpub/account and address nodes
   if (PURPOSE_LEGACY != path[0] && PURPOSE_SEGWIT != path[0] &&
       PURPOSE_NSEGWIT != path[0] && PURPOSE_TAPROOT != path[0]) {
-    // purpose index mismatch
+    // unsupported purpose index
     status = false;
   }
   if (COIN_BTC != path[1] || is_non_hardened(path[2])) {

--- a/apps/btc_app/btc_helpers.c
+++ b/apps/btc_app/btc_helpers.c
@@ -1,0 +1,151 @@
+/**
+ * @file    btc_helpers.c
+ * @author  Cypherock X1 Team
+ * @brief   Utilities specific to Bitcoin blockchain
+ * @copyright Copyright (c) 2023 HODL TECH PTE LTD
+ * <br/> You may obtain a copy of license at <a href="https://mitcc.org/"
+ *target=_blank>https://mitcc.org/</a>
+ *
+ ******************************************************************************
+ * @attention
+ *
+ * (c) Copyright 2023 by HODL TECH PTE LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * "Commons Clause" License Condition v1.0
+ *
+ * The Software is provided to you by the Licensor under the License,
+ * as defined below, subject to the following condition.
+ *
+ * Without limiting other conditions in the License, the grant of
+ * rights under the License will not include, and the License does not
+ * grant to you, the right to Sell the Software.
+ *
+ * For purposes of the foregoing, "Sell" means practicing any or all
+ * of the rights granted to you under the License to provide to third
+ * parties, for a fee or other consideration (including without
+ * limitation fees for hosting or consulting/ support services related
+ * to the Software), a product or service whose value derives, entirely
+ * or substantially, from the functionality of the Software. Any license
+ * notice or attribution required by the License must also include
+ * this Commons Clause License Condition notice.
+ *
+ * Software: All X1Wallet associated files.
+ * License: MIT
+ * Licensor: HODL TECH PTE LTD
+ *
+ ******************************************************************************
+ */
+
+/*****************************************************************************
+ * INCLUDES
+ *****************************************************************************/
+
+#include "btc_helpers.h"
+
+/*****************************************************************************
+ * EXTERN VARIABLES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * PRIVATE MACROS AND DEFINES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * PRIVATE TYPEDEFS
+ *****************************************************************************/
+
+/*****************************************************************************
+ * STATIC FUNCTION PROTOTYPES
+ *****************************************************************************/
+
+/**
+ * @brief Checks if the provided 32-bit value has its MSB not set.
+ *
+ * @return true   If the provided value has MSB set to 0.
+ * @return false  If the provided value has MSB set to 1.
+ */
+static inline bool is_non_hardened(uint32_t x);
+
+/**
+ * @brief Checks if the provided 32-bit value has its MSB set.
+ *
+ * @return true   If the provided value has MSB set to 1.
+ * @return false  If the provided value has MSB set to 0.
+ */
+static inline bool is_hardened(uint32_t x);
+
+/*****************************************************************************
+ * STATIC VARIABLES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * GLOBAL VARIABLES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * STATIC FUNCTIONS
+ *****************************************************************************/
+
+static inline bool is_non_hardened(uint32_t x) {
+  return ((x & 0x80000000) == 0);
+}
+
+static inline bool is_hardened(uint32_t x) {
+  return ((x & 0x80000000) == 0x80000000);
+}
+
+/*****************************************************************************
+ * GLOBAL FUNCTIONS
+ *****************************************************************************/
+
+bool btc_derivation_path_guard(const uint32_t *path, uint32_t depth) {
+  bool status = false;
+  if (BTC_ACC_XPUB_DEPTH != depth && BTC_ACC_ADDR_DEPTH != depth) {
+    return status;
+  }
+  status = true;
+
+  // common checks for xpub/account and address nodes
+  if (PURPOSE_LEGACY != path[0] && PURPOSE_SEGWIT != path[0] &&
+      PURPOSE_NSEGWIT != path[0] && PURPOSE_TAPROOT != path[0]) {
+    // purpose index mismatch
+    status = false;
+  }
+  if (COIN_BTC != path[1] || is_non_hardened(path[2])) {
+    // coin index or account hardness mismatch
+    status = false;
+  }
+
+  if (BTC_ACC_ADDR_DEPTH == depth) {
+    // address node specific checks
+    if (is_hardened(path[3]) || is_hardened(path[4])) {
+      // change or address index must be non-hardened
+      status = false;
+    }
+    if (0 != path[3] && 1 != path[3]) {
+      // invalid change address
+      status = false;
+    }
+  }
+  return status;
+}

--- a/apps/btc_app/btc_helpers.h
+++ b/apps/btc_app/btc_helpers.h
@@ -1,0 +1,68 @@
+/**
+ * @file    btc_helpers.h
+ * @author  Cypherock X1 Team
+ * @brief   Utilities api definitions for Bitcoin chain
+ * @copyright Copyright (c) 2023 HODL TECH PTE LTD
+ * <br/> You may obtain a copy of license at <a href="https://mitcc.org/"
+ * target=_blank>https://mitcc.org/</a>
+ */
+#ifndef BTC_HELPERS_H
+#define BTC_HELPERS_H
+
+/*****************************************************************************
+ * INCLUDES
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*****************************************************************************
+ * MACROS AND DEFINES
+ *****************************************************************************/
+
+#define PURPOSE_LEGACY 0x8000002C     // 44'
+#define PURPOSE_SEGWIT 0x80000031     // 49'
+#define PURPOSE_NSEGWIT 0x80000054    // 84'
+#define PURPOSE_TAPROOT 0x80000056    // 86'
+
+#define COIN_BTC 0x80000000            // 0'
+#define COIN_BTC_TESTNET 0x80000001    // 1'
+
+#define BTC_ACC_XPUB_DEPTH 3
+#define BTC_ACC_ADDR_DEPTH 5
+
+/*****************************************************************************
+ * TYPEDEFS
+ *****************************************************************************/
+
+/*****************************************************************************
+ * EXPORTED VARIABLES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * GLOBAL FUNCTION PROTOTYPES
+ *****************************************************************************/
+
+/**
+ * @brief Verifies the derivation path for any inconsistent/unsupported values.
+ * @details The function supports checking for multiple derivation paths. Also,
+ * based on the provided depth value, the function can act as xpub or address
+ * derivation path.
+ * The only allowed depth count is either 3 (account node level) for xpub or 5
+ * (address node level) for public address derivation.
+ * Currently, following purpose indices are allowed: 0x8000002C, 0x80000031,
+ * 0x80000054, 0x80000056.
+ * The only supported coin indices are: 0x80000000 & 0x80000001. The function
+ * accepts 0 & 1 for change indices. For the rest of the levels, only correct
+ * hardness is checked.
+ *
+ * @param[in] path      The derivation path to be checked
+ * @param[in] depth     The number of levels in the derivation path
+ *
+ * @return bool Indicates if the provided path indices are valid
+ * @retval true if the path values are valid
+ * @retval false otherwise
+ */
+bool btc_derivation_path_guard(const uint32_t *path, uint32_t depth);
+
+#endif

--- a/apps/btc_app/get_public_key.c
+++ b/apps/btc_app/get_public_key.c
@@ -167,9 +167,8 @@ static bool validate_request_data(btc_get_public_key_request_t *request) {
   bool status = true;
 
   // TODO: Enable btc/coin specific check
-  if (false ==
-      btc_derivation_path_guard(request->initiate.derivation_path,
-                                request->initiate.derivation_path_count)) {
+  if (!btc_derivation_path_guard(request->initiate.derivation_path,
+                                 request->initiate.derivation_path_count)) {
     btc_send_error(ERROR_COMMON_ERROR_CORRUPT_DATA_TAG,
                    ERROR_DATA_FLOW_INVALID_DATA);
     status = false;

--- a/apps/btc_app/get_public_key.c
+++ b/apps/btc_app/get_public_key.c
@@ -64,6 +64,7 @@
 #include "btc.h"
 #include "btc/core.pb.h"
 #include "btc_api.h"
+#include "btc_helpers.h"
 #include "pb_encode.h"
 #include "status_api.h"
 #include "ui_core_confirm.h"
@@ -167,8 +168,8 @@ static bool validate_request_data(btc_get_public_key_request_t *request) {
 
   // TODO: Enable btc/coin specific check
   if (false ==
-      verify_receive_derivation_path(request->initiate.derivation_path,
-                                     request->initiate.derivation_path_count)) {
+      btc_derivation_path_guard(request->initiate.derivation_path,
+                                request->initiate.derivation_path_count)) {
     btc_send_error(ERROR_COMMON_ERROR_CORRUPT_DATA_TAG,
                    ERROR_DATA_FLOW_INVALID_DATA);
     status = false;

--- a/apps/btc_app/get_xpub.c
+++ b/apps/btc_app/get_xpub.c
@@ -61,6 +61,7 @@
  *****************************************************************************/
 
 #include "btc_api.h"
+#include "btc_helpers.h"
 #include "common_error.h"
 #include "status_api.h"
 #include "ui_core_confirm.h"
@@ -196,7 +197,7 @@ static bool validate_request_data(btc_get_xpubs_request_t *request) {
   for (pb_size_t index = 0; index < count; index++) {
     path = &request->initiate.derivation_paths[index];
     // TODO: Enable btc/coin specific check
-    if (false == verify_xpub_derivation_path(path->path, path->path_count)) {
+    if (false == btc_derivation_path_guard(path->path, path->path_count)) {
       btc_send_error(ERROR_COMMON_ERROR_CORRUPT_DATA_TAG,
                      ERROR_DATA_FLOW_INVALID_DATA);
       status = false;

--- a/apps/btc_app/get_xpub.c
+++ b/apps/btc_app/get_xpub.c
@@ -197,7 +197,7 @@ static bool validate_request_data(btc_get_xpubs_request_t *request) {
   for (pb_size_t index = 0; index < count; index++) {
     path = &request->initiate.derivation_paths[index];
     // TODO: Enable btc/coin specific check
-    if (false == btc_derivation_path_guard(path->path, path->path_count)) {
+    if (!btc_derivation_path_guard(path->path, path->path_count)) {
       btc_send_error(ERROR_COMMON_ERROR_CORRUPT_DATA_TAG,
                      ERROR_DATA_FLOW_INVALID_DATA);
       status = false;

--- a/tests/common/util/xpub_verify_tests.c
+++ b/tests/common/util/xpub_verify_tests.c
@@ -1,4 +1,5 @@
 #include "btc.h"
+#include "btc_helpers.h"
 #include "coin_utils.h"
 #include "eth.h"
 #include "near.h"
@@ -145,7 +146,21 @@ TEST(xpub, derivation_path_tests) {
   for (int i = 0; i < sizeof(paths) / (7 * sizeof(uint32_t)); i++) {
     bool validity = paths[i][1] == 1;
     uint16_t depth = (uint16_t)paths[i][0];
-    bool status = verify_xpub_derivation_path(&paths[i][2], depth);
+    bool status = false;
+    switch (paths[i][3]) {
+      case BITCOIN:
+        status = btc_derivation_path_guard(&paths[i][2], depth);
+        break;
+      case NEAR:
+        status = near_verify_derivation_path(&paths[i][2], depth);
+        break;
+      case SOLANA:
+        status = sol_verify_derivation_path(&paths[i][2], depth);
+        break;
+      default:
+        status = verify_xpub_derivation_path(&paths[i][2], depth);
+        break;
+    }
 
     TEST_ASSERT(validity == status);
   }


### PR DESCRIPTION
Implements https://app.clickup.com/t/9002019994/PRF-4825

Add specialized API for validating derivation paths for the Bitcoin chain only. The existing API for this purpose has mixed handling for all the Bitcoin forks and Ethereum as well.