### PR TITLE
fix: Update nano pb compile definition to exclude error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,4 +46,4 @@ target_include_directories( ${EXECUTABLE} PRIVATE vendor/nanopb generated/proto 
 
 # Enable support for dynamically allocated fields in nanopb
 # Ref: vendor/nanopb/pb.h
-add_compile_definitions(PB_ENABLE_MALLOC=1)
+add_compile_definitions(PB_ENABLE_MALLOC=1 PB_NO_ERRMSG=1)


### PR DESCRIPTION
PB_NO_ERRMSG configuration reduces the rodata section of the nano pb library as the error messages are excluded which are not used in the X1 vault firmware project