### PR TITLE
refactor: Port card operation to view card version and enable setting

### DIFF
--- a/common/coin_support/wallet.h
+++ b/common/coin_support/wallet.h
@@ -19,7 +19,13 @@
 
 #define FAMILY_ID_SIZE 4
 #define CARD_ID_SIZE (FAMILY_ID_SIZE + 1)
-#define CARD_VERSION_SIZE (2 + 4)
+
+#define CARD_VERSION_MAJOR_MINOR_SIZE 1
+#define CARD_VERSION_PATCH_SIZE 1
+#define CARD_VERSION_GIT_REV_SIZE 4
+#define CARD_VERSION_SIZE                                                      \
+  (CARD_VERSION_MAJOR_MINOR_SIZE + CARD_VERSION_PATCH_SIZE +                   \
+   CARD_VERSION_GIT_REV_SIZE)
 
 #define BLOCK_SIZE 32
 #define NONCE_SIZE 16

--- a/src/card_operations/card_internal.c
+++ b/src/card_operations/card_internal.c
@@ -175,7 +175,7 @@ static void select_applet_and_update_tapped_card(
   uint8_t temp = nfc_data->acceptable_cards;
   nfc_data->status = nfc_select_applet(nfc_data->family_id,
                                        &nfc_data->acceptable_cards,
-                                       NULL,
+                                       nfc_data->card_version,
                                        nfc_data->card_key_id,
                                        &nfc_data->recovery_mode);
 

--- a/src/card_operations/read_card_version.c
+++ b/src/card_operations/read_card_version.c
@@ -103,6 +103,7 @@ bool read_card_version(uint8_t *card_version,
   card_operation_data_t card_data = {0};
   card_data.nfc_data.retries = 5;
   card_data.nfc_data.card_version = card_version;
+  card_data.nfc_data.init_session_keys = false;
 
   instruction_scr_init(msg, heading);
 

--- a/src/card_operations/read_card_version.c
+++ b/src/card_operations/read_card_version.c
@@ -1,8 +1,7 @@
 /**
- * @file    card_settings.c
+ * @file    read_card_version.c
  * @author  Cypherock X1 Team
- * @brief   Source file with helper functions related to X1 vault and X1 card
- *          mutual configuration
+ * @brief   Logic to read card ID from X1 card
  * @copyright Copyright (c) 2023 HODL TECH PTE LTD
  * <br/> You may obtain a copy of license at <a href="https://mitcc.org/"
  *target=_blank>https://mitcc.org/</a>
@@ -60,14 +59,11 @@
 /*****************************************************************************
  * INCLUDES
  *****************************************************************************/
-#include "card_flow_pairing.h"
-#include "constant_texts.h"
-#include "flash_api.h"
-#include "read_card_version.h"
-#include "settings_api.h"
+#include "card_internal.h"
+#include "card_return_codes.h"
+#include "card_utils.h"
+#include "nfc.h"
 #include "ui_screens.h"
-#include "ui_state_machine.h"
-#include "utils.h"
 
 /*****************************************************************************
  * EXTERN VARIABLES
@@ -100,58 +96,45 @@
 /*****************************************************************************
  * GLOBAL FUNCTIONS
  *****************************************************************************/
-void pair_x1_cards(void) {
-  uint8_t new_cards_paired = 0;
+bool read_card_version(uint8_t *card_version,
+                       const char *heading,
+                       const char *msg) {
+  bool result = false;
+  card_operation_data_t card_data = {0};
+  card_data.nfc_data.retries = 5;
+  card_data.nfc_data.card_version = card_version;
 
-  // In case any error occurred return early
-  if (false == card_flow_pairing(&new_cards_paired)) {
-    return;
-  }
+  instruction_scr_init(msg, heading);
 
-  if (MAX_KEYSTORE_ENTRY == get_keystore_used_count()) {
-    delay_scr_init(ui_text_card_pairing_success, DELAY_TIME);
-  } else {
-    // Display newly paired cards to the user
-    if (0 < new_cards_paired) {
-      char msg[100] = {0};
-      snprintf(msg, sizeof(msg), PAIR_CARD_MESSAGE, new_cards_paired);
-      delay_scr_init(msg, DELAY_TIME);
+  while (1) {
+    memset(
+        card_data.nfc_data.family_id, DEFAULT_VALUE_IN_FLASH, FAMILY_ID_SIZE);
+    card_data.nfc_data.acceptable_cards = ACCEPTABLE_CARDS_ALL;
+
+    card_initialize_applet(&card_data);
+
+    if (CARD_OPERATION_SUCCESS == card_data.error_type) {
+      buzzer_start(BUZZER_DURATION);
+      result = true;
+      break;
+    } else {
+      card_handle_errors(&card_data);
     }
-    delay_scr_init(ui_text_card_pairing_warning, DELAY_TIME);
+
+    if ((CARD_OPERATION_CARD_REMOVED == card_data.error_type) ||
+        (CARD_OPERATION_RETAP_BY_USER_REQUIRED == card_data.error_type)) {
+      const char *error_msg = card_data.error_message;
+      if (CARD_OPERATION_SUCCESS == indicate_card_error(error_msg)) {
+        // Re-render the instruction screen
+        instruction_scr_init(msg, heading);
+        continue;
+      }
+    }
+
+    // If control reached here, it is an unrecoverable error, so break
+    result = false;
+    break;
   }
 
-  return;
-}
-
-void view_card_version(void) {
-  uint8_t card_version[CARD_VERSION_SIZE] = {0};
-
-  if (!read_card_version(card_version, NULL, ui_text_tap_a_card)) {
-    return;
-  }
-
-  char msg[100] = {0};
-  char git_revision[CARD_VERSION_GIT_REV_SIZE + 1] = {0};
-
-  uint8_t major_version = (card_version[0] & 0xf0) >> 4;
-  uint8_t minor_version = (card_version[0] & 0x0f);
-  uint8_t patch = card_version[1];
-
-  byte_array_to_hex_string(
-      &card_version[2], 4, git_revision, sizeof(git_revision));
-
-  snprintf(msg,
-           sizeof(msg),
-           UI_TEXT_CARD_VERSION,
-           major_version,
-           minor_version,
-           patch,
-           git_revision);
-
-  message_scr_init(msg);
-
-  // Do not care about the return value from confirmation screen
-  (void)get_state_on_confirm_scr(0, 0, 0);
-
-  return;
+  return result;
 }

--- a/src/card_operations/read_card_version.h
+++ b/src/card_operations/read_card_version.h
@@ -1,0 +1,51 @@
+/**
+ * @file    read_card_version.h
+ * @author  Cypherock X1 Team
+ * @brief   API to read card version details
+ * @copyright Copyright (c) 2023 HODL TECH PTE LTD
+ * <br/> You may obtain a copy of license at <a href="https://mitcc.org/"
+ * target=_blank>https://mitcc.org/</a>
+ */
+#ifndef READ_CARD_VERSION_H
+#define READ_CARD_VERSION_H
+
+/*****************************************************************************
+ * INCLUDES
+ *****************************************************************************/
+#include <stdbool.h>
+#include <stdint.h>
+
+/*****************************************************************************
+ * MACROS AND DEFINES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * TYPEDEFS
+ *****************************************************************************/
+
+/*****************************************************************************
+ * EXPORTED VARIABLES
+ *****************************************************************************/
+
+/*****************************************************************************
+ * GLOBAL FUNCTION PROTOTYPES
+ *****************************************************************************/
+
+/**
+ * @brief This card operation reads the card version from an X1 card
+ * irrespective of it's pairing status
+ *
+ * @param card_version Pointer to buffer of size CARD_VERSION_SIZE which will be
+ * filled by this function in case a valid X1 card is detected
+ * @param heading The heading that needs to be displayed
+ * @param msg The message prompt that needs to be displayed to the user
+ * @return true If the operation was successful, and the card_version populated
+ * with valid data
+ * @return false If the operation was un-successful (eg: Card abort error or P0
+ * error occurred)
+ */
+bool read_card_version(uint8_t *card_version,
+                       const char *heading,
+                       const char *msg);
+
+#endif /* READ_CARD_VERSION_H */

--- a/src/constant_texts.h
+++ b/src/constant_texts.h
@@ -38,8 +38,6 @@
 #define UI_TEXT_EIP712_DOMAIN_TYPE "EIP712Domain"
 #define UI_TEXT_INCORRECT_PIN_ATTEMPTS_REMAINING                               \
   "Incorrect PIN!\n%d attempt(s) remaining"
-#define UI_TEXT_FIRMWARE_VERSION "Firmware Version\n%d.%d.%d-%s"
-#define UI_TEXT_BOOTLOADER_VERSION "Bootloader Version\n%d.%d.%d"
 
 // product hash
 extern const char *product_hash;
@@ -87,6 +85,11 @@ extern const char *ui_text_options_buzzer_adjust[];
 // Regulatory info text
 #define NUMBER_OF_SLIDES_REGULATORY_INFO 5
 extern const char *ui_text_regulatory_info[];
+
+// Version info text
+#define UI_TEXT_CARD_VERSION "Card Version\n%d.%d.%d-%s"
+#define UI_TEXT_FIRMWARE_VERSION "Firmware Version\n%d.%d.%d-%s"
+#define UI_TEXT_BOOTLOADER_VERSION "Bootloader Version\n%d.%d.%d"
 
 // Manager app text
 // Device authentication text

--- a/src/level_four/tap_cards/controller/controller_tap_cards.h
+++ b/src/level_four/tap_cards/controller/controller_tap_cards.h
@@ -42,6 +42,7 @@ typedef struct NFC_connection_data {
   uint8_t card_key_id[4];
   uint8_t recovery_mode;
   uint8_t card_absent_retries;
+  uint8_t *card_version;
   bool init_session_keys;
   ISO7816 status;
 } NFC_connection_data;
@@ -164,22 +165,6 @@ void tap_a_card_and_sync_controller();
  * @note
  */
 void delete_from_cards_controller();
-
-/**
- * @brief
- * @details
- *
- * @param
- *
- * @return
- * @retval
- *
- * @see
- * @since v1.0.0
- *
- * @note
- */
-void controller_read_card_id();
 
 /**
  * @brief

--- a/src/level_four/tap_cards/tasks/tap_one_card_tasks.c
+++ b/src/level_four/tap_cards/tasks/tap_one_card_tasks.c
@@ -78,7 +78,6 @@ extern char *ALPHA_NUMERIC;
 extern char *NUMBERS;
 extern char *HEX;
 char card_id_fetched[2 * CARD_ID_SIZE + 1];
-char card_version[2 * CARD_VERSION_SIZE + 1];
 
 extern bool no_wallet_on_cards;
 void tap_a_card_and_sync_task() {
@@ -106,38 +105,6 @@ void tap_a_card_and_sync_task() {
       break;
     default:
       break;
-  }
-}
-
-static void get_card_version(char *arr, char message[22]) {
-  int offset = snprintf(message, 22, "Card version\n ");
-  message[offset++] = arr[0], message[offset++] = '.',
-  message[offset++] = arr[1], message[offset++] = '.';
-  if (arr[2] != '0')
-    message[offset++] = arr[2], message[offset++] = arr[3];
-  else
-    message[offset++] = arr[3], message[offset++] = 0;
-}
-
-void tasks_read_card_id() {
-  switch (flow_level.level_three) {    // revert back from level_three to
-                                       // level_four if broken
-    case TAP_ONE_CARD_TAP_A_CARD_FRONTEND:
-      instruction_scr_init(ui_text_tap_a_card, NULL);
-      mark_event_over();
-      break;
-    case TAP_ONE_CARD_TAP_A_CARD_BACKEND:
-      mark_event_over();
-      break;
-    case TAP_ONE_CARD_SUCCESS_MESSAGE: {
-      char message[22];
-      get_card_version(card_version, message);
-      message_scr_init((const char *)message);
-      break;
-
-      default:
-        break;
-    }
   }
 }
 

--- a/src/level_four/tap_cards/tasks/tasks_tap_cards.h
+++ b/src/level_four/tap_cards/tasks/tasks_tap_cards.h
@@ -95,22 +95,6 @@ void tap_threshold_cards_for_reconstruction();
 void tap_a_card_and_sync_task();
 
 /**
- * @brief reads card id from a card
- * @details
- *
- * @param
- *
- * @return
- * @retval
- *
- * @see
- * @since v1.0.0
- *
- * @note
- */
-void tasks_read_card_id();
-
-/**
  * @brief Task to update card id
  * @details
  *

--- a/src/level_one/controller/controller_level_one.h
+++ b/src/level_one/controller/controller_level_one.h
@@ -60,7 +60,7 @@ void level_one_controller_b();
  * the level one in initial application. Post card tapping (last step of
  * training), the USB is initialised for communication.
  *
- * @see flow_level, counter, mark_device_state(), controller_read_card_id(),
+ * @see flow_level, counter, mark_device_state(),
  * reset_flow_level() MX_USB_DEVICE_Init()
  * @since v1.0.0
  *

--- a/src/level_one/controller/controller_level_one_initial.c
+++ b/src/level_one/controller/controller_level_one_initial.c
@@ -101,13 +101,11 @@ void level_one_controller_initial() {
     } break;
 
     case 4: {
-      controller_read_card_id();
       reset_flow_level();
       flow_level.level_one = 5;
     } break;
 
     case 5: {
-      controller_read_card_id();
       char msg[32] = {'\0'};
       snprintf(msg,
                sizeof(msg),

--- a/src/level_one/tasks/tasks_level_one.h
+++ b/src/level_one/tasks/tasks_level_one.h
@@ -41,7 +41,7 @@ void level_one_tasks();
  * task handler will enable desktop request handler and render appropriate
  * display based on the current level one state of the application.
  *
- * @see flow_level, counter, tasks_read_card_id(), instruction_scr_init()
+ * @see flow_level, counter, instruction_scr_init()
  * @since v1.0.0
  */
 void level_one_tasks_initial();

--- a/src/level_one/tasks/tasks_level_one_initial.c
+++ b/src/level_one/tasks/tasks_level_one_initial.c
@@ -116,7 +116,7 @@ void level_one_tasks_initial() {
 
     case 4: {
       flow_level.level_three = TAP_ONE_CARD_TAP_A_CARD_FRONTEND;
-      tasks_read_card_id();
+      // tasks_read_card_id();
       instruction_scr_destructor();
       instruction_scr_init(ui_text_tap_a_card_instruction2, NULL);
     } break;

--- a/src/level_three/advanced_settings/controller/advanced_settings_controller.c
+++ b/src/level_three/advanced_settings/controller/advanced_settings_controller.c
@@ -108,7 +108,6 @@ void level_three_advanced_settings_controller() {
       break;
 
     case LEVEL_THREE_READ_CARD_VERSION: {
-      controller_read_card_id();
     } break;
 #if X1WALLET_MAIN
     case LEVEL_THREE_REGULATORY_INFO: {

--- a/src/level_three/advanced_settings/controller/controller_advanced_settings.h
+++ b/src/level_three/advanced_settings/controller/controller_advanced_settings.h
@@ -25,7 +25,7 @@
  * state based on the user's input (as communication via lvgl's UI components).
  *
  * @see LEVEL_THREE_ADVANCED_SETTINGS_TASKS, initial_verify_card_controller(),
- * level_three_advanced_settings_tasks(), controller_read_card_id(),
+ * level_three_advanced_settings_tasks(),
  * get_usb_msg_by_cmd_type(), device_provision_controller(),
  * device_authentication_controller(), tap_card_pair_card_controller()
  * @since v1.0.0

--- a/src/level_three/advanced_settings/tasks/advanced_settings_tasks.c
+++ b/src/level_three/advanced_settings/tasks/advanced_settings_tasks.c
@@ -138,7 +138,6 @@ void level_three_advanced_settings_tasks() {
     } break;
 
     case LEVEL_THREE_READ_CARD_VERSION: {
-      tasks_read_card_id();
     } break;
 
     case LEVEL_THREE_REGULATORY_INFO: {

--- a/src/level_three/advanced_settings/tasks/tasks_advanced_settings.h
+++ b/src/level_three/advanced_settings/tasks/tasks_advanced_settings.h
@@ -26,7 +26,7 @@
  * upgrade, card verification along with card pairing.
  *
  * @see LEVEL_THREE_ADVANCED_SETTINGS_TASKS, initial_verify_card_task(),
- * verify_card_task(), tasks_read_card_id(), tap_a_card_and_sync_task(),
+ * verify_card_task(),  tap_a_card_and_sync_task(),
  * sync_cards_task(), task_device_provision()
  * @since v1.0.0
  */

--- a/src/menu/settings_menu.c
+++ b/src/menu/settings_menu.c
@@ -196,6 +196,10 @@ static void settings_menu_handler(engine_ctx_t *ctx,
         view_firmware_version();
         break;
       }
+      case VIEW_CARD_VERSION: {
+        view_card_version();
+        break;
+      }
       case VIEW_REGULATORY_INFO: {
         view_device_regulatory_information();
         break;

--- a/src/settings/settings_api.h
+++ b/src/settings/settings_api.h
@@ -69,4 +69,11 @@ void view_device_regulatory_information(void);
  *
  */
 void pair_x1_cards(void);
+
+/**
+ * @brief This function displays the version details of an X1 card
+ *
+ */
+void view_card_version(void);
+
 #endif /* SETTINGS_API_H */


### PR DESCRIPTION
This pull request enables viewing X1 card version. A new field `card_version` is added in `nfc_connection_data` structure, which can hold a pointer to buffer where the card version will be copied on card tap.

Fixes https://app.clickup.com/t/9002019994/PRF-4845