### PR TITLE
refactor: Remove 'CARD_OPERATION_PAIRING_REQUIRED' card error type

### DIFF
--- a/src/card_operations/card_internal.c
+++ b/src/card_operations/card_internal.c
@@ -287,9 +287,8 @@ card_error_type_e card_initialize_applet(card_operation_data_t *card_data) {
         if (true == card_data->nfc_data.init_session_keys) {
           /* Return pairing error if not paired */
           if (false == load_card_session_key(card_data->nfc_data.card_key_id)) {
-            NFC_RETURN_ERROR_WITH_MSG(card_data,
-                                      CARD_OPERATION_PAIRING_REQUIRED,
-                                      ui_text_device_and_card_not_paired);
+            NFC_RETURN_ABORT_ERROR(card_data,
+                                   ui_text_device_and_card_not_paired);
           }
         }
 
@@ -344,9 +343,7 @@ card_error_type_e card_handle_errors(card_operation_data_t *card_data) {
        * doesn't. In practice this would happen if the card was paired with more
        * than 5 devices after being paired to the device where error occurs. */
       invalidate_keystore();
-      NFC_RETURN_ERROR_WITH_MSG(card_data,
-                                CARD_OPERATION_PAIRING_REQUIRED,
-                                ui_text_device_and_card_not_paired);
+      NFC_RETURN_ABORT_ERROR(card_data, ui_text_device_and_card_not_paired);
       break;
     case SW_CONDITIONS_NOT_SATISFIED:
       break;

--- a/src/card_operations/card_return_codes.h
+++ b/src/card_operations/card_return_codes.h
@@ -25,11 +25,10 @@
  *****************************************************************************/
 typedef enum card_errors_type {
   CARD_OPERATION_SUCCESS = 0,
-  CARD_OPERATION_CARD_REMOVED,     /** When card is removed before operation
-                                      completion*/
-  CARD_OPERATION_PAIRING_REQUIRED, /** Returned after card is unpaired */
-  CARD_OPERATION_LOCKED_WALLET,    /** Locked wallet detected during wallet
-                                      operation */
+  CARD_OPERATION_CARD_REMOVED,  /** When card is removed before operation
+                                   completion*/
+  CARD_OPERATION_LOCKED_WALLET, /** Locked wallet detected during wallet
+                                   operation */
   CARD_OPERATION_INCORRECT_PIN_ENTERED, /** Incorrect pin entered */
   CARD_OPERATION_P0_OCCURED,            /** P0 event occured */
 

--- a/src/wallet/reconstruct_seed_flow.c
+++ b/src/wallet/reconstruct_seed_flow.c
@@ -203,7 +203,6 @@ reconstruct_state_e reconstruct_seed_handler(reconstruct_state_e state,
         next_state = PIN_INPUT;
       } else {
         /* In case of other status code returned by the card operation:
-         * CARD_OPERATION_PAIRING_REQUIRED,
          * CARD_OPERATION_LOCKED_WALLET,
          * CARD_OPERATION_P0_OCCURED,
          * CARD_OPERATION_ABORT_OPERATION


### PR DESCRIPTION
This PR replaces `CARD_OERATION_PAIRING_REQUIRED` error code with `CARD_OPERATION_ABORT_OPERATION` since it is also a terminal case in card flows which require pairing which is configured through `init_session_keys`.