### PR TITLE
fix: Clear usb event on abort in flows

### DIFF
--- a/common/core/core_error.c
+++ b/common/core/core_error.c
@@ -154,6 +154,11 @@ void handle_core_errors() {
     /* TODO: Send message to host if P0 occured if core status is set to usb */
   }
 
+  if (true == evt.abort_evt) {
+    usb_clear_event();
+    p0_reset_evt();
+  }
+
   display_core_error();
   return;
 }

--- a/common/core/core_error_priv.h
+++ b/common/core/core_error_priv.h
@@ -33,8 +33,10 @@
  * @brief Handle P0 timeout event and display error message set by core
  * opearations using @ref mark_core_error_screen. In case of P0 timeout event,
  * message is displayed (if local error message buffer was empty) and a core
- * error is sent to host. After P0 handling, if a core error message was set,
- * that message is displayed.
+ * error is sent to host. In case of abort event from the host, the usb event
+ * is cleared so that stale event does not go to application in next event loop.
+ * After P0 handling, if a core error message was set, that message is displayed
+ * if inactivity was the reason.
  *
  * NOTE:
  * 1. Should be called on initialization of a core flow like main menu or


### PR DESCRIPTION
As a part of post-abort handling device core error handler will clear the usb events for completeness of the flow exit sequence. Not doing so would result in handling of stale usb events by the application.