### PR TITLE
fix: Refresh timeout counter in case joystick movement is detected

### DIFF
--- a/common/core/events.c
+++ b/common/core/events.c
@@ -112,6 +112,11 @@ evt_status_t get_events(uint8_t event_config, uint32_t timeout) {
     if (EVENT_CONFIG_UI == (event_config & EVENT_CONFIG_UI)) {
       lv_task_handler();
       p1_evt_occurred |= ui_get_and_reset_event(&(status.ui_event));
+
+      if (keypad_get_key()) {
+        // Refresh the timeout as a user activity is detected on the joystick
+        p0_ctx_init(timeout);
+      }
     }
 
     if (EVENT_CONFIG_USB == (event_config & EVENT_CONFIG_USB)) {

--- a/src/main.c
+++ b/src/main.c
@@ -160,8 +160,6 @@ int main(void) {
   }
 #else /* RUN_ENGINE */
   while (true) {
-    if (keypad_get_key() != 0)
-      reset_inactivity_timer();
     proof_of_work_task();
 
 #if USE_SIMULATOR == 1


### PR DESCRIPTION
Implements https://app.clickup.com/t/9002019994/PRF-5022