### PR TITLE
feat(core): Removed unnecessary steps for provisoning

### DIFF
--- a/common/startup/application_startup.c
+++ b/common/startup/application_startup.c
@@ -348,9 +348,7 @@ void application_init() {
   BSP_I2C1_Init();
   BSP_RNG_Init();
   atecc_mode_detect();
-#if X1WALLET_MAIN
   libusb_init();
-#endif
   // Timer3 interrupt
   BSP_TIM3_Base_Start_IT();
   BSP_App_Timer_Init();

--- a/common/startup/application_startup.c
+++ b/common/startup/application_startup.c
@@ -539,7 +539,9 @@ void device_provision_check() {
 #if USE_SIMULATOR == 0
   const char *msg = NULL;
 
-  switch (check_provision_status()) {
+  provision_status_t status = check_provision_status();
+
+  switch (status) {
     default:
     case provision_empty:
       msg = ui_text_device_compromised_not_provisioned;
@@ -562,6 +564,7 @@ void device_provision_check() {
 #if NDEBUG
   msg = ui_text_device_compromised;
 #endif
+  LOG_INFO("Provision status: %d", status);
   ui_set_event_over_cb(NULL);
   delay_scr_init(msg, DELAY_TIME);
   ui_set_event_over_cb(&mark_event_over);

--- a/src/controller_main.c
+++ b/src/controller_main.c
@@ -896,14 +896,11 @@ void desktop_listener_task(lv_task_t *data) {
 #endif
       case START_FIRMWARE_UPGRADE: {
         CY_Reset_Not_Allow(false);
-        snprintf(flow_level.confirmation_screen_text,
-                 sizeof(flow_level.confirmation_screen_text),
-                 "Update firmware to version %d.%d.%d",
-                 data_array[0],
-                 data_array[1],
-                 (uint16_t)(data_array[3] | ((uint16_t)data_array[2] << 8)));
+        reset_flow_level();
+        CY_Set_External_Triggered(true);
+        counter.level = LEVEL_THREE;
+        lv_obj_clean(lv_scr_act());
         flow_level.level_one = LEVEL_TWO_ADVANCED_SETTINGS;
-        flow_level.show_desktop_start_screen = true;
         flow_level.level_two = LEVEL_THREE_RESET_DEVICE_CONFIRM;
         clear_message_received_data();
       } break;

--- a/src/level_four/core/controller/initial_device_provision_contoller.c
+++ b/src/level_four/core/controller/initial_device_provision_contoller.c
@@ -169,9 +169,19 @@ provision_status_t check_provision_status() {
                    0x00) {    // NFC private key slot not locked
       return provision_v1_complete;
     } else {
+      LOG_INFO("cfg bytes\n86:%02x, 87:%02x, 88:%02x, 89:%02x",
+               cfg[86],
+               cfg[87],
+               cfg[88],
+               cfg[89]);
       return provision_empty;
     }
   } else {
+    LOG_INFO("cfg bytes\n86:%02x, 87:%02x, 88:%02x, 89:%02x",
+             cfg[86],
+             cfg[87],
+             cfg[88],
+             cfg[89]);
     return provision_empty;
   }
 }
@@ -453,7 +463,7 @@ void device_provision_controller() {
       } else {
         comm_reject_request(CONFIRM_PROVISION, 0);
         flow_level.level_three = PROVISION_UNSUCCESSFUL;
-        LOG_ERROR("PERR2-KEY");
+        LOG_ERROR("PERR6-KEY");
         break;
       }
       reset_flow_level();

--- a/src/level_four/core/controller/initial_device_provision_contoller.c
+++ b/src/level_four/core/controller/initial_device_provision_contoller.c
@@ -336,11 +336,16 @@ void device_provision_controller() {
         } else if (provision_status == provision_incomplete) {
           get_device_serial();
         } else {
+          transmit_one_byte_confirm(CONFIRM_PROVISION);
+          if (usb_irq_enable_on_entry == true)
+            NVIC_EnableIRQ(OTG_FS_IRQn);
           lv_obj_clean(lv_scr_act());
-          mark_error_screen(ui_text_device_already_provisioned);
+          instruction_scr_init(ui_text_device_already_provisioned, NULL);
+          lv_task_handler();
+          BSP_DelayMs(2000);
+          instruction_scr_destructor();
           reset_flow_level();
           flow_level.level_one = 6;
-          flow_level.show_error_screen = true;
           return;
         }
       } while ((atecc_data.status != ATCA_SUCCESS) && (--atecc_data.retries));

--- a/src/level_one/controller/controller_level_one_initial.c
+++ b/src/level_one/controller/controller_level_one_initial.c
@@ -93,7 +93,7 @@ void level_one_controller_initial() {
   switch (flow_level.level_one) {
     case 1:
     case 2: {
-      flow_level.level_one++;
+      flow_level.level_one = 6;
     } break;
 
     case 3: {

--- a/src/level_one/tasks/tasks_level_one_initial.c
+++ b/src/level_one/tasks/tasks_level_one_initial.c
@@ -102,7 +102,7 @@ void level_one_tasks_initial() {
 
   switch (flow_level.level_one) {
     case 1: {
-      delay_scr_init("WELCOME", DELAY_TIME);
+      mark_event_over();
     } break;
 
     case 2: {

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-firmware version=000:004:012:003
+firmware version=000:004:013:000
 hardware version=000:001:000:000
 magic number=45227A01


### PR DESCRIPTION
Changes in this PR:
- USB enabled at startup in the initial app
- Joystick training and card training removed
- Handling of devices already provisioned improved to send a response to the host.
- Skipped confirmation for firmware update
- Updated and added logs for provisioning state and errors