### PR TITLE
feat(core): Verify wallet id on reconstruction

### DIFF
--- a/common/libraries/util/wallet_utilities.c
+++ b/common/libraries/util/wallet_utilities.c
@@ -90,6 +90,20 @@ void calculate_wallet_id(uint8_t wallet_id[WALLET_ID_SIZE],
   sha256_Raw(wallet_id, SHA256_DIGEST_LENGTH, wallet_id);
 }
 
+bool verify_wallet_id(const uint8_t wallet_id[WALLET_ID_SIZE],
+                      const char *mnemonics) {
+  uint8_t generated_wallet_id[WALLET_ID_SIZE] = {0};
+
+  calculate_wallet_id(generated_wallet_id, mnemonics);
+  if (0 == memcmp(wallet_id, generated_wallet_id, WALLET_ID_SIZE)) {
+    return true;
+  } else {
+    log_hex_array("Expected wallet id: ", wallet_id, WALLET_ID_SIZE);
+    log_hex_array("Generated wallet id: ", generated_wallet_id, WALLET_ID_SIZE);
+    return false;
+  }
+}
+
 void derive_beneficiary_key(
     uint8_t beneficiary_key[BENEFICIARY_KEY_SIZE],
     uint8_t iv_for_beneficiary_key[IV_FOR_BENEFICIARY_KEY_SIZE],

--- a/common/libraries/util/wallet_utilities.h
+++ b/common/libraries/util/wallet_utilities.h
@@ -27,6 +27,16 @@
 #include "wallet.h"
 
 /**
+ * @brief Verify wallet id with wallet id generated from mnemonics
+ *
+ * @return true if all wallet id matches the wallet id generated from mnemonics,
+ * else false
+ *
+ */
+bool verify_wallet_id(const uint8_t wallet_id[WALLET_ID_SIZE],
+                      const char *mnemonics);
+
+/**
  * @brief Calculate wallet id from mnemonics
  * @details
  *

--- a/src/constant_texts.c
+++ b/src/constant_texts.c
@@ -270,7 +270,7 @@ const char *ui_text_wallet_doesnt_exists_on_this_card =
 const char *ui_text_wallet_verification_failed_in_creation =
     "Wallet not created Proceed for deletion";
 const char *ui_text_wallet_verification_failed_in_reconstruction =
-    "Wallet verification failed during reconstruction";
+    "Verification failed.\n Contact support.";
 const char *ui_text_no_response_from_desktop =
     "No response from the cySync app!\nTry again";
 

--- a/src/constant_texts.c
+++ b/src/constant_texts.c
@@ -267,8 +267,10 @@ const char *ui_text_wrong_card_sequence = "Wrong card sequence";
 const char *ui_text_tap_another_card = "Tap another card";
 const char *ui_text_wallet_doesnt_exists_on_this_card =
     "Wallet does not exist on this card";
-const char *ui_text_wallet_verification_failed =
+const char *ui_text_wallet_verification_failed_in_creation =
     "Wallet not created Proceed for deletion";
+const char *ui_text_wallet_verification_failed_in_reconstruction =
+    "Wallet verification failed during reconstruction";
 const char *ui_text_no_response_from_desktop =
     "No response from the cySync app!\nTry again";
 

--- a/src/constant_texts.h
+++ b/src/constant_texts.h
@@ -198,7 +198,8 @@ extern const char *ui_text_tap_another_card;
 extern const char *ui_text_wallet_doesnt_exists_on_this_card;
 extern const char *ui_text_wrong_wallet_is_now_locked;
 extern const char *ui_text_wallet_already_unlocked;
-extern const char *ui_text_wallet_verification_failed;
+extern const char *ui_text_wallet_verification_failed_in_creation;
+extern const char *ui_text_wallet_verification_failed_in_reconstruction;
 
 extern const char *ui_text_invalid_card_tap_card[];
 extern const char *ui_text_device_authenticating[];

--- a/src/level_four/core/controller/verify_wallet_controller.c
+++ b/src/level_four/core/controller/verify_wallet_controller.c
@@ -103,7 +103,7 @@ void verify_wallet_controller() {
       break;
 
     case VERIFY_WALLET_DELETE:
-      mark_error_screen(ui_text_wallet_verification_failed);
+      mark_error_screen(ui_text_wallet_verification_failed_in_creation);
       flow_level.level_three = 1;
       break;
 

--- a/src/menu/wallet_menu.c
+++ b/src/menu/wallet_menu.c
@@ -245,7 +245,7 @@ static void wallet_menu_handler(engine_ctx_t *ctx,
           // If post verification, the wallet state was updated to INVALID,
           // proceed to delete that wallet
           if (INVALID_WALLET == wallet_ptr->state) {
-            message_scr_init(ui_text_wallet_verification_failed);
+            message_scr_init(ui_text_wallet_verification_failed_in_creation);
             if (0 != get_state_on_confirm_scr(0, 1, 2)) {
               break;
             }

--- a/src/wallet/reconstruct_wallet_flow.c
+++ b/src/wallet/reconstruct_wallet_flow.c
@@ -130,39 +130,36 @@ static reconstruct_state_e reconstruct_wallet_handler(reconstruct_state_e state,
                                                       rejection_cb *reject_cb);
 
 /**
- * @brief The function takes a wallet ID, a pointer to an output buffer, and an
- * initial state, and runs a flow to reconstruct a secret based on the wallet
- * ID.
+ * @brief This function takes wallet ID, an initial state, and a rejection
+ * callback function as input, and reconstructs a wallet by running a series of
+ * handlers until it reaches a completion state, returning the generated
+ * mnemonics if successful.
  *
- * @param wallet_id A pointer to a uint8_t array that represents the wallet id.
- * @param secret_out A pointer to a uint8_t array where the reconstructed secret
- * will be stored.
- * @param init_state The initial state of the secret reconstruction flow. It
- * determines where the flow should start from.
+ * @param wallet_id A pointer to the wallet ID, which is an array of uint8_t
+ * (unsigned 8-bit integers).
+ * @param init_state The initial state of the wallet reconstruction process. It
+ * determines where the reconstruction process should start from.
  * @param reject_cb Callback to execute if there is any rejection during PIN or
  * passphrase input occurs, or a card abort error occurs
  *
- * @return The function is expected to return a value of type
- * `reconstruct_state_e`.
+ * @return a pointer to a constant character mnemonics string (const char *).
  */
 static const char *reconstruct_wallet(const uint8_t *wallet_id,
                                       reconstruct_state_e init_state,
                                       rejection_cb *reject_cb);
 
 /**
- * The function generates mnemonic words from a secret and verifies a wallet ID,
- * returning the number of mnemonic words if successful.
+ * @brief The function generates mnemonics from a secret and verifies a wallet
+ * ID using those mnemonics.
  *
- * @param wallet_id A pointer to a uint8_t array representing the wallet ID.
- * @param mnemonic_list A 2-dimensional array of characters that will store the
- * generated mnemonics. Each row of the array represents a single mnemonic word,
- * and the maximum number of mnemonic words is defined by
- * MAX_NUMBER_OF_MNEMONIC_WORDS. The maximum length of each mnemonic word is
- * defined by MAX_MNEMON
- * @param secret The `secret` parameter is a pointer to a uint8_t array that
- * contains the secret data used to generate the mnemonic words.
+ * @param secret A pointer to an array of uint8_t, which represents the secret
+ * data used to generate the mnemonics.
+ * @param wallet_id The `wallet_id` parameter is a pointer to a constant array
+ * of `uint8_t` (unsigned 8-bit integers). wallet_id is compared against the
+ * wallet id generated from mnemonics, if same wallet id is generated, then
+ * wallet is verified.
  *
- * @return a uint8_t value, which represents the result of the operation.
+ * @return a pointer to a constant character mnemonics string (const char *).
  */
 static const char *generate_mnemonics_and_verify_wallet(
     uint8_t *secret,
@@ -359,8 +356,8 @@ static const char *reconstruct_wallet(const uint8_t *wallet_id,
     mnemonics = generate_mnemonics_and_verify_wallet(secret, wallet_id);
     if (NULL == mnemonics) {
       if (reject_cb) {
-        reject_cb(ERROR_COMMON_ERROR_WALLET_NOT_FOUND_TAG,
-                  ERROR_WALLET_NOT_FOUND_ON_CARD);
+        reject_cb(ERROR_COMMON_ERROR_CARD_ERROR_TAG,
+                  ERROR_CARD_ERROR_SW_RECORD_NOT_FOUND);
       }
       current_state = COMPLETED_WITH_ERRORS;
     }

--- a/src/wallet/reconstruct_wallet_flow.c
+++ b/src/wallet/reconstruct_wallet_flow.c
@@ -154,15 +154,14 @@ static const char *reconstruct_wallet(const uint8_t *wallet_id,
  *
  * @param secret A pointer to an array of uint8_t, which represents the secret
  * data used to generate the mnemonics.
- * @param wallet_id The `wallet_id` parameter is a pointer to a constant array
- * of `uint8_t` (unsigned 8-bit integers). wallet_id is compared against the
- * wallet id generated from mnemonics, if same wallet id is generated, then
- * wallet is verified.
+ * @param wallet_id A pointer to an array uint8_t with wallet id, wallet_id  is
+ * compared against the wallet id generated from mnemonics, if same wallet id is
+ * generated, then wallet is verified.
  *
  * @return a pointer to a constant character mnemonics string (const char *).
  */
 static const char *generate_mnemonics_and_verify_wallet(
-    uint8_t *secret,
+    const uint8_t *secret,
     const uint8_t *wallet_id);
 
 /*****************************************************************************
@@ -315,7 +314,7 @@ static reconstruct_state_e reconstruct_wallet_handler(reconstruct_state_e state,
 }
 
 static const char *generate_mnemonics_and_verify_wallet(
-    uint8_t *secret,
+    const uint8_t *secret,
     const uint8_t *wallet_id) {
   const char *mnemonics =
       mnemonic_from_data(secret, wallet.number_of_mnemonics * 4 / 3);
@@ -367,6 +366,7 @@ static const char *reconstruct_wallet(const uint8_t *wallet_id,
               ERROR_USER_REJECTION_CONFIRMATION);
   }
 
+  memzero(secret, sizeof(secret));
   return mnemonics;
 }
 


### PR DESCRIPTION
With this change, the wallet ID is generated and verified every time the seed/mnemonics is reconstructed.
- This would prevent wallet collision when the two shares are generated from the same mnemonics and wallet name but in different sessions.