### PR TITLE
chore: Update cmake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.3)
+cmake_minimum_required(VERSION 3.19.0)
 set(CMAKE_MESSAGE_LOG_LEVEL debug)
 
 if("${CMAKE_BUILD_PLATFORM}" STREQUAL "Device")


### PR DESCRIPTION
The cmake function (`execute_process`) uses new features that were introduced in version 3.19.0 ( [Refer here](https://cmake.org/cmake/help/latest/command/execute_process.html)).