### PR TITLE
fix (core): Set default pow-nonce to 0xff in sync wallets

### DIFF
--- a/common/interfaces/flash_interface/flash_api.c
+++ b/common/interfaces/flash_interface/flash_api.c
@@ -724,7 +724,7 @@ int set_wallet_locked(const char *wallet_name, uint8_t encoded_card_number) {
   flash_wallet->is_wallet_locked = true;
   memzero(&(flash_wallet->challenge), sizeof(flash_wallet->challenge));
   flash_wallet->challenge.card_locked = encoded_card_number;
-  memset(flash_wallet->challenge.nonce, 0xFF, PADDED_NONCE_SIZE);
+  memset(flash_wallet->challenge.nonce, 0xFF, POW_NONCE_SIZE);
   flash_struct_save();
   return SUCCESS;
 }
@@ -804,7 +804,7 @@ int update_wallet_locked_flash(const char *name, const bool is_wallet_locked) {
     flash_wallet->challenge.time_to_unlock_in_secs = 0;
 
     // Reset nonce to 0xFF as challenge is not fetched
-    memset(flash_wallet->challenge.nonce, 0xFF, PADDED_NONCE_SIZE);
+    memset(flash_wallet->challenge.nonce, 0xFF, POW_NONCE_SIZE);
   } else {
     // Wallet unlocked, reset challenge
     memzero(&(flash_wallet->challenge), sizeof(flash_wallet->challenge));

--- a/src/settings/sync_with_cards.c
+++ b/src/settings/sync_with_cards.c
@@ -177,6 +177,7 @@ static bool sync_wallets_in_flash(const wallet_list_t *wallet_list,
     // Record card number on which the wallet is locked
     if (new_wallet.is_wallet_locked) {
       new_wallet.challenge.card_locked = *tapped_card;
+      memset(new_wallet.challenge.nonce, 0xFF, POW_NONCE_SIZE);
     }
 
     uint32_t flash_index = MAX_WALLETS_ALLOWED;

--- a/src/wallet/wallet_unlock_flow.c
+++ b/src/wallet/wallet_unlock_flow.c
@@ -149,7 +149,7 @@ static wallet_unlock_state_e wallet_unlock_handler(
  *****************************************************************************/
 
 static bool check_default_nonce(const uint8_t *nonce) {
-  for (size_t i = 0; i < PADDED_NONCE_SIZE; i++) {
+  for (size_t i = 0; i < POW_NONCE_SIZE; i++) {
     if (nonce[i] != DEFAULT_VALUE_IN_FLASH) {
       return false;
     }


### PR DESCRIPTION
The nonce value indicates if the wallet unlocking is initialized. The value 0xff...ff (32-bytes) is an indicative of uninitialized state while any other value will indicate progress of the unlocking process. Currently, The sync-wallet flow sets it to 0 which causes the unlock flow to skip card tapping step from the user.
Fixes https://app.clickup.com/t/9002019994/PRF-6961