### PR TITLE
hotfix (app): Evm payload function arg parser update

### DIFF
--- a/apps/evm_family/evm_contracts.c
+++ b/apps/evm_family/evm_contracts.c
@@ -281,7 +281,13 @@ uint8_t ETH_ExtractArguments(const uint8_t *pAbiPayload,
   const uint8_t *pPayloadBasePtr = pCurrHeadPtr;
   uint8_t currArgument;
 
-  for (currArgument = 0; currArgument < numArgsInFunction; currArgument++) {
+  for (currArgument = 0; currArgument <= numArgsInFunction; currArgument++) {
+    // only return OK when completely parsed whole payload
+    if ((pAbiPayload + sizeOfPayload) == pCurrHeadPtr) {
+      returnCode = ETH_UTXN_ABI_DECODE_OK;
+      break;
+    }
+
     /* Ensure that we are reading from within the bounds */
     if (UTIL_IN_BOUNDS != UTIL_CheckBound(pAbiPayload,
                                           sizeOfPayload,
@@ -345,7 +351,6 @@ uint8_t ETH_ExtractArguments(const uint8_t *pAbiPayload,
     }
 
     pCurrHeadPtr += ABI_ELEMENT_SZ_IN_BYTES;
-    returnCode = ETH_UTXN_ABI_DECODE_OK;
 
     if (*displayNode == NULL) {
       *displayNode = pAbiDispNode;

--- a/apps/evm_family/evm_contracts.c
+++ b/apps/evm_family/evm_contracts.c
@@ -281,13 +281,12 @@ uint8_t ETH_ExtractArguments(const uint8_t *pAbiPayload,
   const uint8_t *pPayloadBasePtr = pCurrHeadPtr;
   uint8_t currArgument;
 
-  for (currArgument = 0; currArgument <= numArgsInFunction; currArgument++) {
-    // only return OK when completely parsed whole payload
-    if ((pAbiPayload + sizeOfPayload) == pCurrHeadPtr) {
-      returnCode = ETH_UTXN_ABI_DECODE_OK;
-      break;
-    }
+  // if argument count is zero (eg. `deposit`), it's an immediate success
+  if (0 == numArgsInFunction) {
+    returnCode = ETH_UTXN_ABI_DECODE_OK;
+  }
 
+  for (currArgument = 0; currArgument < numArgsInFunction; currArgument++) {
     /* Ensure that we are reading from within the bounds */
     if (UTIL_IN_BOUNDS != UTIL_CheckBound(pAbiPayload,
                                           sizeOfPayload,
@@ -351,6 +350,7 @@ uint8_t ETH_ExtractArguments(const uint8_t *pAbiPayload,
     }
 
     pCurrHeadPtr += ABI_ELEMENT_SZ_IN_BYTES;
+    returnCode = ETH_UTXN_ABI_DECODE_OK;
 
     if (*displayNode == NULL) {
       *displayNode = pAbiDispNode;

--- a/tests/unit_test_lists.c
+++ b/tests/unit_test_lists.c
@@ -176,12 +176,11 @@ TEST_GROUP_RUNNER(btc_script_test) {
 }
 
 TEST_GROUP_RUNNER(evm_txn_test) {
-#ifdef EVM_TXN_MANUAL_TEST
   RUN_TEST_CASE(evm_txn_test, evm_txn_eth_transfer);
   RUN_TEST_CASE(evm_txn_test, evm_txn_usdt_transfer);
   RUN_TEST_CASE(evm_txn_test, evm_txn_haka_transfer);
   RUN_TEST_CASE(evm_txn_test, evm_txn_blind_signing);
-#endif
+  RUN_TEST_CASE(evm_txn_test, evm_txn_token_deposit);
 }
 
 TEST_GROUP_RUNNER(evm_sign_msg_test) {

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-firmware version=000:006:000:000
+firmware version=000:006:000:001
 hardware version=000:001:000:000
 magic number=45227A01


### PR DESCRIPTION
Fixes https://app.clickup.com/t/9002019994/PRF-7131

The functions with 0 arguments result into ETH_BAD_ARGUMENTS which is incorrect. Update the parser to return OK if all of the payload is parsed irrespective of the number of arguments.