### PR TITLE
chore (tests): Update escaping of non-printable characters

### DIFF
--- a/common/libraries/util/utils.c
+++ b/common/libraries/util/utils.c
@@ -623,8 +623,10 @@ uint8_t string_to_escaped_string(const char *input,
     bool g_ret = lv_font_get_glyph_dsc(font_p, &g, letter, '\0');
     uint8_t bytes_read = in_idx - old_idx;
 
-    if (0 != letter && true == g_ret) {
-      // the glyph exists; keep the encoded character as it is
+    if (0 != letter && ('\n' == letter || '\r' == letter || true == g_ret)) {
+      // the glyph exists; keep the encoded character as it is.
+      // Additionally, CR/LF characters are handled as special case by LVGL
+      // hence glyphs for CR/LF are meaningless so we should keep it as it is
       if ((out_idx + bytes_read + 1) >= out_len)
         return 5;
       memcpy(&escaped_string[out_idx], &input[old_idx], bytes_read);

--- a/common/libraries/util/utils.c
+++ b/common/libraries/util/utils.c
@@ -627,6 +627,7 @@ uint8_t string_to_escaped_string(const char *input,
       // the glyph exists; keep the encoded character as it is.
       // Additionally, CR/LF characters are handled as special case by LVGL
       // hence glyphs for CR/LF are meaningless so we should keep it as it is
+      // refer common/lvgl/src/lv_misc/lv_txt.c#174
       if ((out_idx + bytes_read + 1) >= out_len)
         return 5;
       memcpy(&escaped_string[out_idx], &input[old_idx], bytes_read);

--- a/tests/common/util/utils_tests.c
+++ b/tests/common/util/utils_tests.c
@@ -145,10 +145,10 @@ TEST(utils_tests, escape_string_ascii) {
   // message:
   // "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n0123456789
   // !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~"
-  char utf_8_string[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz"
-                        "\n0123456789 !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~";
+  char utf_8_string[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\r\nabcdefghijklmnopqrstuvwx"
+                        "yz\n0123456789\r !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~";
   const char expected_string[] =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n0123456789 "
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ\r\nabcdefghijklmnopqrstuvwxyz\n0123456789\r "
       "!\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~";
   char actual_string[300] = "";
 

--- a/tests/common/util/utils_tests.c
+++ b/tests/common/util/utils_tests.c
@@ -142,9 +142,14 @@ TEST(utils_tests, escape_string_symbol) {
 }
 
 TEST(utils_tests, escape_string_ascii) {
-  // message: "ASCII sample text"
-  char utf_8_string[] = "ASCII sample text";
-  const char expected_string[] = "ASCII sample text";
+  // message:
+  // "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n0123456789
+  // !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~"
+  char utf_8_string[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz"
+                        "\n0123456789 !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~";
+  const char expected_string[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz\n0123456789 "
+      "!\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~";
   char actual_string[300] = "";
 
   uint8_t result = string_to_escaped_string(


### PR DESCRIPTION
Fixes https://app.clickup.com/t/9002019994/PRF-6382


Steps to Re-create:
1. Visit https://etherscan.io/verifiedSignatures#
2. Use "Sign Message" button
3. Use "wallet Connect" to connect the X1 Vault.
4. Write the following message
```
This message contains £ (pound) 

symbol which is not supported in X1 Vault.
```
6. Click on "Sign Message" button
7. Observe on X1 Vault screen the pound symbol (£) will be shown as hex string after this change. Prior to this, the pound symbol (£) will be completely absent as if it never existed.
