### PR TITLE
fix: corrected the receive text in xrp

### DIFF
--- a/apps/xrp_app/xrp_pub_key.c
+++ b/apps/xrp_app/xrp_pub_key.c
@@ -340,11 +340,7 @@ static bool get_user_consent(const pb_size_t which_request,
     snprintf(
         msg, sizeof(msg), UI_TEXT_ADD_ACCOUNT_PROMPT, XRP_NAME, wallet_name);
   } else {
-    snprintf(msg,
-             sizeof(msg),
-             UI_TEXT_RECEIVE_PROMPT,
-             XRP_NAME,
-             wallet_name);
+    snprintf(msg, sizeof(msg), UI_TEXT_RECEIVE_PROMPT, XRP_NAME, wallet_name);
   }
 
   return core_scroll_page(NULL, msg, xrp_send_error);

--- a/apps/xrp_app/xrp_pub_key.c
+++ b/apps/xrp_app/xrp_pub_key.c
@@ -342,8 +342,7 @@ static bool get_user_consent(const pb_size_t which_request,
   } else {
     snprintf(msg,
              sizeof(msg),
-             UI_TEXT_RECEIVE_TOKEN_PROMPT,
-             XRP_LUNIT,
+             UI_TEXT_RECEIVE_PROMPT,
              XRP_NAME,
              wallet_name);
   }


### PR DESCRIPTION
Corrects the receive confirmation text on device for xrp

Steps to Reproduce:
  1. Initiate receive address for XRP
  2. Check for text on device

Actual Behaviour:
 - Text shown is "Receive XRP on XRP in <wallet_name>"
 
Expected Behaviour:
- Text should be "Receive XRP in <wallet_name>"