### PR TITLE
Hotfix/btc parser out of bounds

### DIFF
--- a/apps/btc_family/btc_txn.c
+++ b/apps/btc_family/btc_txn.c
@@ -435,7 +435,7 @@ static bool fetch_valid_input(btc_query_t *query) {
 
         verify_input_data.size_last_chunk = total_size % CHUNK_SIZE;
         if (verify_input_data.size_last_chunk < 4) {
-          verify_input_data.isLocktimeSplit = true;
+          verify_input_data.is_locktime_split = true;
         }
       }
 

--- a/apps/btc_family/btc_txn_helpers.h
+++ b/apps/btc_family/btc_txn_helpers.h
@@ -51,10 +51,10 @@ typedef struct btc_verify_input {
   parse_type parsetype;
   input_case input_parse;
   output_case output_parse;
-  bool isSegwit;
-  bool isSplit;
-  bool hasLocktime;
-  bool isLocktimeSplit;
+  bool is_segwit;
+  bool is_split;
+  bool has_locktime;
+  bool is_locktime_split;
   int32_t size_last_chunk;
   uint8_t value[8];
   uint8_t locktime[4];

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-firmware version=000:006:005:000
+firmware version=000:006:005:001
 hardware version=000:001:000:000
 magic number=45227A01


### PR DESCRIPTION
Btc prev txn verification going out of bounds due to missing equality operator in offset incerement;
Add other improvements regarding chunking and variable naming. 