### PR TITLE
fix: Use maximum size for length check

### DIFF
--- a/apps/inheritance_app/inheritance_decrypt_data.c
+++ b/apps/inheritance_app/inheritance_decrypt_data.c
@@ -430,7 +430,7 @@ static bool inheritance_get_encrypted_data(inheritance_query_t *query) {
 
     if (false == query->decrypt.encrypted_data.has_chunk_payload ||
         payload->chunk_index >= payload->total_chunks ||
-        size + chunk->size > total_size) {
+        size + chunk->size > INHERITANCE_PACKET_MAX_SIZE) {
       SET_ERROR_TYPE(DECRYPTION_CHUNK_DATA_INVALID_ERROR);
       return false;
     }

--- a/apps/inheritance_app/inheritance_encrypt_data.c
+++ b/apps/inheritance_app/inheritance_encrypt_data.c
@@ -497,7 +497,7 @@ static bool inheritance_get_plain_data(inheritance_query_t *query) {
 
     if (false == query->encrypt.plain_data.has_chunk_payload ||
         payload->chunk_index >= payload->total_chunks ||
-        size + chunk->size > total_size) {
+        size + chunk->size > INHERITANCE_PACKET_MAX_SIZE) {
       SET_ERROR_TYPE(ENCRYPTION_CHUNK_DATA_INVALID_ERROR);
       return false;
     }


### PR DESCRIPTION
Instead of checking total size received from communication check the max size for Inheritance packet, because we are allocating buffer on stack